### PR TITLE
Adaptive mesh v2

### DIFF
--- a/hardware/probe.cfg
+++ b/hardware/probe.cfg
@@ -20,7 +20,7 @@ probe_switch_x: 198.5
 probe_switch_y: 285.5
 # Switch offset (default D2F-5: 0.5mm and SSG-5H: 0.7mm)
 # Smaller number means higher nozzle to the PEI
-switch_offset: 0.250
+switch_offset: 0.220
 max_deviation: 0.750
 samples: 3
 speed: 350 # X,Y movements

--- a/macros/helpers/nozzle_cleaning.cfg
+++ b/macros/helpers/nozzle_cleaning.cfg
@@ -5,8 +5,10 @@ gcode:
     {% set St = printer["gcode_macro _USER_VARIABLES"].travel_speed * 60 %}
     {% set Sz = printer["gcode_macro _USER_VARIABLES"].z_drop_speed * 60 %}
     {% set Sc = printer["gcode_macro _USER_VARIABLES"].brush_clean_speed * 60 %}
+
     {% set Px = printer["gcode_macro _USER_VARIABLES"].purge_bucket_x %}
     {% set Py = printer["gcode_macro _USER_VARIABLES"].purge_bucket_y %}
+
     {% set Bx = printer["gcode_macro _USER_VARIABLES"].brush_x %}
     {% set By = printer["gcode_macro _USER_VARIABLES"].brush_y %}
     {% set Bz = printer["gcode_macro _USER_VARIABLES"].brush_z %}
@@ -42,6 +44,8 @@ gcode:
     {% set TEMP = params.TEMP|default(230)|float %}
 
     {% set St = printer["gcode_macro _USER_VARIABLES"].travel_speed * 60 %}
+    {% set Sz = printer["gcode_macro _USER_VARIABLES"].z_drop_speed * 60 %}
+
     {% set Px = printer["gcode_macro _USER_VARIABLES"].purge_bucket_x %}
     {% set Py = printer["gcode_macro _USER_VARIABLES"].purge_bucket_y %}
     {% set Pz = printer["gcode_macro _USER_VARIABLES"].purge_bucket_z %}
@@ -61,7 +65,8 @@ gcode:
     G1 E-1.7 F2100
     G1 E-18.3 F150
 
-    # Wait 5s to let the nozzle ooze before cleaning
-    G4 P{5 * 1000}
+    # Wait 20s to let the nozzle ooze before cleaning
+    G1 Z{Pz|int + 5} F{Sz}
+    G4 P{20 * 1000}
   
     G92 E0

--- a/macros/probing/bed_mesh.cfg
+++ b/macros/probing/bed_mesh.cfg
@@ -2,46 +2,79 @@
 ########## ADAPTIVE BED MESH ############
 #########################################
 # Written by Frix_x#0161 #
+# @version: 2.0
+
+# CHANGELOG:
+#   v2.0: split in multple macros to be able to use the center point in the z calibration bed probing position before doing the mesh.
+#   v1.1: fix for a bug when parsing string when using uppercase letters in the [bed_mesh] section
+#   v1.0: first adaptive bed mesh macro
+
 
 ### What is it ? ###
-
 # The adaptive bed mesh is simple: it's a normal bed mesh, but only "where" and "when" it's necessary.
 # Sometime I print small parts, sometime I print full plates and I like to get a precise bed_mesh (like 9x9 or more). However, it take a
-# lot of time and it's useless to probe all the plate for only a 5cm² part in the center. So this is where the adaptive bed mesh is helping:
+# lot of time and it's useless to probe all the plate for only a 5cm² part. So this is where the adaptive bed mesh is helping:
 # 1. It get the corners coordinates of the fisrt layer surface from the slicer
 # 2. It compute a new set of points to probe on this new zone to get at least the same precision as your standard bed mesh. For example, if
 #    a normal bed mesh is set to 9x9 for 300mm², it will then compute 3x3 for a 100mm² surface. Also if for whatever reason your parts are in
 #    the corner of the build plate (like for a damaged PEI in the center), it will follow them to probe this exact area.
-# 3. As the probed point computed are odd, it will also compute the new relative reference index point in the center of the zone
-# 4. To go further, the macro will not do any bed_mesh if there is less than 3x3 points to probe (very small part alone) and choose/change the
+# 3. As the probed points computed are odd, it will also compute the new relative reference index point in the center of the zone and save
+#    the coordinates of this point to use them somwhere else (like the probed point of the auto z calibration plugin for example).
+# 4. To go further, it will not do any bed_mesh if there is less than 3x3 points to probe (very small part alone) and choose/change the
 #    algorithm (bicubic/lagrange) depending of the size and shape of the mesh computed (like 3x3 vs 3x9)
 
+# -------------------------------------------------------------------------------------------------------------------------
 ### Installation ###
-# 1. You need to change some custom settings in your slicer:
-#      a. SuperSlicer is easy: add in your custom g_code PRINT_START macro the SIZE argument like this:
+# 1. You need to change some settings in your slicer:
+#      a. SuperSlicer is easy: change your custom g_code PRINT_START macro to add the SIZE argument like this:
 #               PRINT_START [all your shit..] SIZE={first_layer_print_min[0]}_{first_layer_print_min[1]}_{first_layer_print_max[0]}_{first_layer_print_max[1]}
 #      b. Cura is a bit more tricky as you need to install the post process plugin by frankbags called MeshPrintSize.py.
 #               In Cura menu, click Help > Show configuration folder. Copy the python script from the following link into the plugins folder: https://gist.github.com/frankbags/c85d37d9faff7bce67b6d18ec4e716ff#file-meshprintsize-py
 #               Then restart Cura and select in the menu: Extensions > Post processing > select Mesh Print Size
-#               At the end, change your custom g_code PRINT_START macro the SIZE argument like this:
+#               At the end, change your custom g_code PRINT_START macro to add the SIZE argument like this:
 #               PRINT_START [all your shit..] SIZE=%MINX%_%MINY%_%MAXX%_%MAXY%
 # 2. In klipper, configure a normal [bed_mesh] section in your config as you want for your machine (it will be the base to compute the new adaptive bed mesh). Keep
-#    in mind that you can push the precision a little bit with a mesh of 9x9 for example as not all the points will be probed.
+#    in mind that you can push further the precision a little bit with a mesh of 9x9 for example as not all the points will be probed for smaller parts.
 # 3. VERY IMPORTANT CHECKS:
-#      a. Be sure to put the "mesh_pps" entry in the [bed_mesh] section. You can choose what you want or let it to default, but even if it's optional for Klipper, it's mandatory
-#         to really specify it in your config for my macro to work correctly.
+#      a. Be sure to put the "mesh_pps" entry in the [bed_mesh] section. You can choose what you want or let it to the default value (2,2). Even if it's optional for Klipper,
+#         it's mandatory to specify it in your config for my macro to work correctly.
 #      b. Also check that the mesh_min, mesh_max, probe_count and mesh_pps configs entry in your [bed_mesh] section are specified using double numbers like "probe_count: 9,9"
 #         as my macro is waiting for TWO numbers and will fail if there is only one specified at thoose positions.
-# 4. In your PRINT_START macro definition, get the SIZE argument and pass it to the ADAPTIVE_BED_MESH to start the probing sequence like so:
-#    {% set FL_SIZE = params.SIZE|default("0_0_0_0")|string %}
-#    ADAPTIVE_BED_MESH SIZE={FL_SIZE}
-# 5. Optional: my macro is using the RESPOND command for debugging purposes: add the [respond] section to your config or delete all the RESPOND lines in my macro
+# 4. Optional check: my macro is using the RESPOND command for debugging purposes: either add the [respond] section to your config or delete all the RESPOND lines in my macro
+# 5. Finally, there is two way to use this set of macros:
+#      a. Normal easy way for most of the users (retro-compatible with version 1): in your klipper config, modify your PRINT_START macro definition to get 
+#         the SIZE argument and then call the ADAPTIVE_BED_MESH macro with it to start the probing sequence like so:
+#             {% set FL_SIZE = params.SIZE|default("0_0_0_0")|string %}
+#             ADAPTIVE_BED_MESH SIZE={FL_SIZE}
+#      b. For power users that also use the auto z_calibration plugin: in your klipper config, modify your PRINT_START macro definition to get
+#         the SIZE argument and then call the COMPUTE_MESH_PARAMETERS macro with it like so:
+#             {% set FL_SIZE = params.SIZE|default("0_0_0_0")|string %}
+#             COMPUTE_MESH_PARAMETERS SIZE={FL_SIZE}
+#         Then you can call the CALIBRATE_Z command with the computed mesh center point (here is a simple example, but look at my own macros for more safety):
+#             {% set mesh_center = printer["gcode_macro _ADAPTIVE_MESH_VARIABLES"].mesh_center %}
+#             CALIBRATE_Z BED_POSITION={mesh_center}
+#         Finally, do a simple call to ADAPTIVE_BED_MESH when you are ready to effectively do the mesh
 
+# -------------------------------------------------------------------------------------------------------------------------
 # Feel free to ping me on Discord (Frix_x#0161) if you need help or have any comments to improve it :)
 
 
-[gcode_macro ADAPTIVE_BED_MESH]
-description: Perform a bed mesh, but only where and when it's needed
+# DO NOT MODIFY THOSE VARIABLES (they are used internaly by the adaptive bed mesh macro)
+[gcode_macro _ADAPTIVE_MESH_VARIABLES]
+variable_ready: False
+variable_do_mesh: False
+variable_do_nominal: False
+variable_mesh_min: 0,0
+variable_mesh_max: 0,0
+variable_mesh_center: 0,0
+variable_probe_count: 0,0
+variable_rri: 0
+variable_algo: "bicubic"
+gcode:
+
+
+[gcode_macro COMPUTE_MESH_PARAMETERS]
+description: Compute the mesh parameters and store them for later use
 gcode:
     # 1 ----- GET ORIGINAL BEDMESH PARAMS FROM CONFIG ----------------------
     {% set xMinConf, yMinConf = printer["configfile"].config["bed_mesh"]["mesh_min"].split(',')|map('trim')|map('int') %}
@@ -50,8 +83,8 @@ gcode:
     {% set algo = printer["configfile"].config["bed_mesh"]["algorithm"]|lower %}
     {% set xMeshPPS, yMeshPPS = printer["configfile"].config["bed_mesh"]["mesh_pps"].split(',')|map('trim')|map('int') %}
 
-    # If the SIZE parameter is defined and set not a dummy placeholder, we do the adaptive
-    # bed mesh logic. If it's ommited, we still do the original BED_MESH_CALIBRATE function
+    # If the SIZE parameter is defined and not a dummy placeholder, we do the adaptive
+    # bed mesh logic. If it's ommited, we do the original BED_MESH_CALIBRATE function (full bed probing)
     {% if params.SIZE is defined and params.SIZE != "0_0_0_0" %}
 
         # 2 ----- GET MESH SIZE AND MARGIN FROM MACRO CALL --------------------
@@ -80,14 +113,19 @@ gcode:
         # At the end we control (according to Klipper bed_mesh method: "_verify_algorithm") that the computed probe_count is
         # valid according to the choosen algorithm or change it if needed.
         {% if xProbeCnt < 3 and yProbeCnt < 3 %}
-            RESPOND MSG="Adaptive bed mesh: mesh not needed"
-            
+            RESPOND MSG="Computed mesh parameters: none, bed mesh not needed"
+            SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=do_mesh VALUE={False}
+
+            {% set xCenter = xMin + ((xMax - xMin) / 2) %}
+            {% set yCenter = yMin + ((yMax - yMin) / 2) %}
+            {% set mesh_center = "%d,%d"|format(xCenter, yCenter) %} # we still compute the mesh center for those using klipper_z_calibration
+            SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=mesh_center VALUE='"{mesh_center}"'
         {% else %}
             {% set xProbeCnt = [3, xProbeCnt]|max %}
             {% set yProbeCnt = [3, yProbeCnt]|max %}
 
-            # We verify that the number of probe points on each axis is odd or add
-            # one to it. This is to have a relative_reference_index point at the center of the mesh
+            # We verify that the number of probe points on each axis is odd or add one to it
+            # This is very important to have a relative_reference_index point at the center of the mesh !
             {% if xProbeCnt % 2 == 0 %}
                 {% set xProbeCnt = xProbeCnt + 1 %}
             {% endif %}
@@ -120,15 +158,88 @@ gcode:
 
             # 5 ----- COMPUTE THE RELATIVE_REFERENCE_INDEX POINT --------------------
             {% set rRefIndex = (((xProbeCnt * yProbeCnt) - 1) / 2)|int %}
+            {% set xCenter = xMin + ((xMax - xMin) / 2) %}
+            {% set yCenter = yMin + ((yMax - yMin) / 2) %}
 
-            # 6 ----- FORMAT THE PARAMETERS TO CALL BED_MESH_CALIBRATE --------------
+            # 6 ----- FORMAT THE PARAMETERS AND SAVE THEM ---------------------------
             {% set mesh_min = "%d,%d"|format(xMin, yMin) %}
             {% set mesh_max = "%d,%d"|format(xMax, yMax) %}
             {% set probe_count = "%d,%d"|format(xProbeCnt, yProbeCnt) %}
+            {% set mesh_center = "%d,%d"|format(xCenter, yCenter) %}
+            RESPOND MSG="Computed mesh parameters: MESH_MIN={mesh_min} MESH_MAX={mesh_max} MESH_CENTER={mesh_center} PROBE_COUNT={probe_count} RELATIVE_REFERENCE_INDEX={rRefIndex} ALGORITHM={algo}"
+            SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=do_mesh VALUE={True}
+            SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=do_nominal VALUE={False}
+            SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=mesh_min VALUE='"{mesh_min}"'
+            SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=mesh_max VALUE='"{mesh_max}"'
+            SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=mesh_center VALUE='"{mesh_center}"'
+            SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=probe_count VALUE='"{probe_count}"'
+            SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=rri VALUE={rRefIndex}
+            SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=algo VALUE='"{algo}"'
+        {% endif %}
+    {% else %}
+        RESPOND MSG="Computed mesh parameters: none, going for a nominal bed mesh"
+        SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=do_mesh VALUE={True}
+        SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=do_nominal VALUE={True}
+
+        {% set xCenter = xMin + ((xMax - xMin) / 2) %}
+        {% set yCenter = yMin + ((yMax - yMin) / 2) %}
+        {% set mesh_center = "%d,%d"|format(xCenter, yCenter) %} # we still compute the mesh center for those using klipper_z_calibration
+        SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=mesh_center VALUE='"{mesh_center}"'
+    {% endif %}
+
+    # Finaly save in the variables that we already computed the values
+    SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=ready VALUE={True}
+
+
+[gcode_macro ADAPTIVE_BED_MESH]
+description: Perform a bed mesh, but only where and when it's needed
+gcode:
+    {% set ready = printer["gcode_macro _ADAPTIVE_MESH_VARIABLES"].ready %}
+
+    {% if not 'xyz' in printer.toolhead.homed_axes %}
+        { action_raise_error("Must Home printer first!") }
+    {% endif %}
+
+    # If the parameters where computed, we can do the mesh by calling the _DO_ADAPTIVE_MESH
+    {% if ready %}
+        _DO_ADAPTIVE_MESH
+
+    # If the parameters where not computed prior to the ADAPTIVE_BED_MESH call, we call the COMPUTE_MESH_PARAMETERS
+    # macro first and then call the _DO_ADAPTIVE_MESH macro after it
+    {% else %}
+        RESPOND MSG="Adaptive bed mesh: parameters not computed, automatically calling the COMPUTE_MESH_PARAMETERS macro prior to the mesh"
+        COMPUTE_MESH_PARAMETERS {rawparams}
+        M400 # mandatory to flush the gcode buffer and be sure to use the last computed parameters
+        _DO_ADAPTIVE_MESH
+    {% endif %}
+
+
+[gcode_macro _DO_ADAPTIVE_MESH]
+gcode:
+    # 1 ----- POPULATE BEDMESH PARAMS FROM SAVED VARIABLES ----------------------
+    {% set do_mesh = printer["gcode_macro _ADAPTIVE_MESH_VARIABLES"].do_mesh %}
+    {% set do_nominal = printer["gcode_macro _ADAPTIVE_MESH_VARIABLES"].do_nominal %}
+    {% set mesh_min = printer["gcode_macro _ADAPTIVE_MESH_VARIABLES"].mesh_min %}
+    {% set mesh_max = printer["gcode_macro _ADAPTIVE_MESH_VARIABLES"].mesh_max %}
+    {% set probe_count = printer["gcode_macro _ADAPTIVE_MESH_VARIABLES"].probe_count %}
+    {% set rRefIndex = printer["gcode_macro _ADAPTIVE_MESH_VARIABLES"].rri %}
+    {% set algo = printer["gcode_macro _ADAPTIVE_MESH_VARIABLES"].algo %}
+
+    # 2 --------- ADAPTIVE_BED_MESH LOGIC --------------------------------------
+
+    # If it's necessary to do a mesh
+    {% if do_mesh %}
+        # If it's a standard bed_mesh to be done
+        {% if do_nominal %}
+            RESPOND MSG="Adaptive bed mesh: nominal bed mesh"
+            BED_MESH_CALIBRATE
+        {% else %}
             RESPOND MSG="Adaptive bed mesh: MESH_MIN={mesh_min} MESH_MAX={mesh_max} PROBE_COUNT={probe_count} RELATIVE_REFERENCE_INDEX={rRefIndex} ALGORITHM={algo}"
             BED_MESH_CALIBRATE MESH_MIN={mesh_min} MESH_MAX={mesh_max} PROBE_COUNT={probe_count} RELATIVE_REFERENCE_INDEX={rRefIndex} ALGORITHM={algo}
         {% endif %}
     {% else %}
-        RESPOND MSG="Adaptive bed mesh: nominal bed mesh"
-        BED_MESH_CALIBRATE
+        RESPOND MSG="Adaptive bed mesh: no mesh to be done"
     {% endif %}
+
+    # Set back the 'ready' parameter to false
+    SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=ready VALUE={False}

--- a/macros/probing/homing_qgl.cfg
+++ b/macros/probing/homing_qgl.cfg
@@ -3,6 +3,8 @@ rename_existing: _BASE_CALIBRATE_Z
 description: Perform the Z calibration using the physical Z endstop and the Klicky
 gcode:
     {% set V = printer["gcode_macro _USER_VARIABLES"].verbose %}
+    {% set mesh_ready = printer["gcode_macro _ADAPTIVE_MESH_VARIABLES"].ready %}
+    {% set mesh_center = printer["gcode_macro _ADAPTIVE_MESH_VARIABLES"].mesh_center %}
 
     {% if not 'xyz' in printer.toolhead.homed_axes %}
         { action_raise_error("Must Home printer first!") }
@@ -15,8 +17,15 @@ gcode:
     ATTACH_PROBE
     G1 X206 F8000 # to avoid the dock
 
-    # Auto Z offset adjustement
-    _BASE_CALIBRATE_Z
+    # Auto Z offset adjustement. If a mesh is ready to be done, we look at the center point
+    # and use it as the bed probing point. klipper_z_calibration plugin minimum version v0.8.2 needed
+    {% if mesh_ready %}
+        RESPOND MSG="Z calibration: a mesh is computed and ready, probing mesh center: {mesh_center}"
+        _BASE_CALIBRATE_Z BED_POSITION={mesh_center}
+    {% else %}
+        RESPOND MSG="Z calibration: no mesh computed, probing default point"
+        _BASE_CALIBRATE_Z
+    {% endif %}
 
     DOCK_PROBE
 

--- a/macros/probing/klicky_probe.cfg
+++ b/macros/probing/klicky_probe.cfg
@@ -3,6 +3,14 @@
 # Heavily modified here by myself to be simpler and adapted to my machine
 ###########################################################################
 
+[gcode_macro _PROBE_VARIABLES]
+variable_probe_attached: False
+variable_probe_state: False
+variable_probe_lock: False
+variable_z_endstop_x: 0
+variable_z_endstop_y: 0
+gcode:
+
 [gcode_macro _EXIT_POINT]
 gcode:
     {% set function  = 'pre_' ~ params.FUNCTION %}

--- a/macros/variables.cfg
+++ b/macros/variables.cfg
@@ -27,19 +27,9 @@ variable_brush_z: 2
 # Purge bucket position
 variable_purge_bucket_x: 20
 variable_purge_bucket_y: 307
-variable_purge_bucket_z: 10
+variable_purge_bucket_z: 5
 
 gcode:
     # Copy the physical Z endstop location to probe variables for Klicky internal functionning
     SET_GCODE_VARIABLE MACRO=_PROBE_VARIABLES VARIABLE=z_endstop_x VALUE={ z_endstop_x }
     SET_GCODE_VARIABLE MACRO=_PROBE_VARIABLES VARIABLE=z_endstop_y VALUE={ z_endstop_y }
-
-
-[gcode_macro _PROBE_VARIABLES]
-variable_probe_attached:            False
-variable_probe_state:               False
-variable_probe_lock:                False
-variable_z_endstop_x:               0
-variable_z_endstop_y:               0
-gcode:
-

--- a/moonraker.conf
+++ b/moonraker.conf
@@ -2,17 +2,33 @@
 host: 0.0.0.0
 port: 7125
 enable_debug_logging: False
+
+[file_manager]
 config_path: ~/klipper_config
+log_path: ~/klipper_logs
+
+[data_store]
 temperature_store_size: 600
 gcode_store_size: 1000
 
+[machine]
+provider: systemd_dbus
+
+# [database]
+# database_path: ~/.moonraker_database
+
+# [job_queue]
+# load_on_startup: False
+# automatic_transition: False
+
 [authorization]
+force_logins: False
 cors_domains:
   *.local
   *.lan
   *://app.fluidd.xyz
+  *://dev-app.fluidd.xyz
   *://my.mainsail.xyz
-
 trusted_clients:
     10.0.0.0/8
     127.0.0.0/8


### PR DESCRIPTION
This PR split my ADAPTIVE_BED_MESH macro in multiple macros to be able to use the new PR from klipper_z_calibration : https://github.com/protoloft/klipper_z_calibration/pull/48

All was done with retro-compatibility in mind and the update should be easy : the mechanisms for the klipper_z_calibration plugin are optional.