### PR TITLE
Fix error on nominal bed mesh

### DIFF
--- a/macros/probing/bed_mesh.cfg
+++ b/macros/probing/bed_mesh.cfg
@@ -182,8 +182,8 @@ gcode:
         SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=do_mesh VALUE={True}
         SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=do_nominal VALUE={True}
 
-        {% set xCenter = xMin + ((xMax - xMin) / 2) %}
-        {% set yCenter = yMin + ((yMax - yMin) / 2) %}
+        {% set xCenter = xMinConf + ((xMaxConf - xMinConf) / 2) %}
+        {% set yCenter = yMinConf + ((yMaxConf - yMinConf) / 2) %}
         {% set mesh_center = "%d,%d"|format(xCenter, yCenter) %} # we still compute the mesh center for those using klipper_z_calibration
         SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=mesh_center VALUE='"{mesh_center}"'
     {% endif %}

--- a/macros/probing/bed_mesh.cfg
+++ b/macros/probing/bed_mesh.cfg
@@ -5,6 +5,7 @@
 # @version: 2.0
 
 # CHANGELOG:
+#   v2.1: fix for the nominal mesh (when no SIZE parameter is used or SIZE=0_0_0_0)
 #   v2.0: split in multple macros to be able to use the center point in the z calibration bed probing position before doing the mesh.
 #   v1.1: fix for a bug when parsing string when using uppercase letters in the [bed_mesh] section
 #   v1.0: first adaptive bed mesh macro


### PR DESCRIPTION
xMin, xMax, etc are defined in an unreachable if statement if nominal bed mesh is required, which gives an undefined variable error on lines 185 and 186 - values from the config should be used instead