### PR TITLE
improvements on dockable probe configuration

### DIFF
--- a/macros/probing/dockable_probe.cfg
+++ b/macros/probing/dockable_probe.cfg
@@ -58,28 +58,26 @@ gcode:
 [gcode_macro _PROBE_MOVE_TO]
 description: positioning toolhead for dock/attach operation
 gcode: 
-
-    {% set location  = params.LOCATION|default('')|string %}
-    {% set distance  = params.DISTANCE|default(0)|float %}
-    {% set speed  = params.SPEED|default(0)|float %}
+    {% set location = params.LOCATION|default('')|string %}
+    {% set distance = params.DISTANCE|default(0)|float %}
+    {% set speed = params.SPEED|default(0)|float %}
 
     {% set probe_dock_location_x, probe_dock_location_y = printer["gcode_macro _USER_VARIABLES"].probe_dock_location_xy|map('float') %}
 
+    # define dict for location direction
+    {% set location_factor = {
+        'left'  : { 'x': -1, 'y':  0 },
+        'right' : { 'x':  1, 'y':  0 },
+        'front' : { 'x':  0, 'y': -1 },
+        'back'  : { 'x':  0, 'y':  1 },
+        'dock'  : { 'x':  0, 'y':  0 }
+    } %}
 
-    # define dict for location
-    {% set location_factor ={   'left'  : { 'x': -1, 'y':  0 },
-                                'right' : { 'x':  1, 'y':  0 },
-                                'front' : { 'x':  0, 'y': -1 },
-                                'back'  : { 'x':  0, 'y':  1 },
-                                'dock'  : { 'x':  0, 'y':  0 }
-                            } %}
-
-    {% if location_factor[location] is defined %}
+    {% if location in location_factor %}
         G1 X{probe_dock_location_x + location_factor[location].x * distance} Y{probe_dock_location_y + location_factor[location].y * distance} F{speed}
     {% else %}
-        { action_raise_error("LOCATION is incorrectly set!") }
+        { action_raise_error("Error in probe attach/dock movement. Check the directions in your variables.cfg file!") }
     {% endif %}
-
 
 
 [gcode_macro ATTACH_PROBE]
@@ -104,8 +102,6 @@ gcode:
     {% set probe_dock_speed = printer["gcode_macro _USER_VARIABLES"].probe_dock_speed * 60 %}
     {% set travel_speed = printer["gcode_macro _USER_VARIABLES"].travel_speed * 60 %}
     {% set z_drop_speed = printer["gcode_macro _USER_VARIABLES"].z_drop_speed * 60 %}
-
-
 
     _ENTRY_POINT FUNCTION=ATTACH_PROBE
 

--- a/macros/probing/dockable_probe.cfg
+++ b/macros/probing/dockable_probe.cfg
@@ -67,10 +67,9 @@ gcode:
     # Get Docking location
     {% set probe_dock_location_x, probe_dock_location_y = printer["gcode_macro _USER_VARIABLES"].probe_dock_location_xy|map('float') %}
 
-    {% set probe_move_to_attach = printer["gcode_macro _USER_VARIABLES"].probe_move_to_attach|string %}
-    {% set probe_move_to_detach = printer["gcode_macro _USER_VARIABLES"].probe_move_to_detach|string %}
+    {% set probe_before_attach_position = printer["gcode_macro _USER_VARIABLES"].probe_before_attach_position|string %}
+    {% set probe_after_attach_position = printer["gcode_macro _USER_VARIABLES"].probe_after_attach_position|string %}
     {% set probe_move_attach_length = printer["gcode_macro _USER_VARIABLES"].probe_move_attach_length %}
-    {% set probe_move_detach_length = printer["gcode_macro _USER_VARIABLES"].probe_move_detach_length %}
 
     # Safe Z for travel
     {% set probe_min_z_travel = printer["gcode_macro _USER_VARIABLES"].probe_min_z_travel|float %}
@@ -101,32 +100,32 @@ gcode:
         {% endif %}
 
         # Probe entry location
-        {% if probe_move_to_attach == 'left' %}
+        {% if probe_before_attach_position == 'left' %}
             G1 X{probe_dock_location_x - probe_move_attach_length} Y{probe_dock_location_y} F{travel_speed}
-        {% elif probe_move_to_attach == 'right' %}
+        {% elif probe_before_attach_position == 'right' %}
             G1 X{probe_dock_location_x + probe_move_attach_length} Y{probe_dock_location_y} F{travel_speed}
-        {% elif probe_move_to_attach == 'front' %}
-            G1 X{probe_dock_location_x} Y{probe_dock_location_y + probe_move_attach_length} F{travel_speed}
-        {% elif probe_move_to_attach == 'back' %}
+        {% elif probe_before_attach_position == 'front' %}
             G1 X{probe_dock_location_x} Y{probe_dock_location_y - probe_move_attach_length} F{travel_speed}
+        {% elif probe_before_attach_position == 'back' %}
+            G1 X{probe_dock_location_x} Y{probe_dock_location_y + probe_move_attach_length} F{travel_speed}
         {% else %}
-            { action_raise_error("variable_probe_move_to_attach is incorrectly set!") }
+            { action_raise_error("variable_probe_before_attach_position is incorrectly set!") }
         {% endif %}
         
         # Pickup from Probe location
         G1 X{probe_dock_location_x} Y{probe_dock_location_y} F{probe_dock_speed}
         
         # Get the probe out of the dock
-        {% if probe_move_to_attach == 'left' %}
+        {% if probe_after_attach_position == 'left' %}
             G1 X{probe_dock_location_x - probe_move_attach_length} Y{probe_dock_location_y} F{probe_dock_speed}
-        {% elif probe_move_to_attach == 'right' %}
+        {% elif probe_after_attach_position == 'right' %}
             G1 X{probe_dock_location_x + probe_move_attach_length} Y{probe_dock_location_y} F{probe_dock_speed}
-        {% elif probe_move_to_attach == 'front' %}
-            G1 X{probe_dock_location_x} Y{probe_dock_location_y + probe_move_attach_length} F{probe_dock_speed}
-        {% elif probe_move_to_attach == 'back' %}
+        {% elif probe_after_attach_position == 'front' %}
             G1 X{probe_dock_location_x} Y{probe_dock_location_y - probe_move_attach_length} F{probe_dock_speed}
+        {% elif probe_after_attach_position == 'back' %}
+            G1 X{probe_dock_location_x} Y{probe_dock_location_y + probe_move_attach_length} F{probe_dock_speed}
         {% else %}
-            { action_raise_error("variable_probe_move_to_attach is incorrectly set!") }
+            { action_raise_error("variable_probe_after_attach_position is incorrectly set!") }
         {% endif %}
 
         _CHECK_PROBE action=attach
@@ -162,10 +161,9 @@ gcode:
     # Get Docking location
     {% set probe_dock_location_x, probe_dock_location_y = printer["gcode_macro _USER_VARIABLES"].probe_dock_location_xy|map('float') %}
     
-    {% set probe_move_to_attach = printer["gcode_macro _USER_VARIABLES"].probe_move_to_attach|string %}
-    {% set probe_move_to_detach = printer["gcode_macro _USER_VARIABLES"].probe_move_to_detach|string %}
-    {% set probe_move_attach_length = printer["gcode_macro _USER_VARIABLES"].probe_move_attach_length %}
-    {% set probe_move_detach_length = printer["gcode_macro _USER_VARIABLES"].probe_move_detach_length %}
+    {% set probe_before_dock_position = printer["gcode_macro _USER_VARIABLES"].probe_before_dock_position|string %}
+    {% set probe_after_dock_position = printer["gcode_macro _USER_VARIABLES"].probe_after_dock_position|string %}
+    {% set probe_move_dock_length = printer["gcode_macro _USER_VARIABLES"].probe_move_dock_length %}
 
     # Safe Z for travel
     {% set probe_min_z_travel = printer["gcode_macro _USER_VARIABLES"].probe_min_z_travel|float %}
@@ -195,32 +193,32 @@ gcode:
         {% endif %}
 
         # Probe entry location
-        {% if probe_move_to_attach == 'left' %}
-            G1 X{probe_dock_location_x - probe_move_attach_length} Y{probe_dock_location_y} F{travel_speed}
-        {% elif probe_move_to_attach == 'right' %}
-            G1 X{probe_dock_location_x + probe_move_attach_length} Y{probe_dock_location_y} F{travel_speed}
-        {% elif probe_move_to_attach == 'front' %}
-            G1 X{probe_dock_location_x} Y{probe_dock_location_y + probe_move_attach_length} F{travel_speed}
-        {% elif probe_move_to_attach == 'back' %}
-            G1 X{probe_dock_location_x} Y{probe_dock_location_y - probe_move_attach_length} F{travel_speed}
+        {% if probe_before_dock_position == 'left' %}
+            G1 X{probe_dock_location_x - probe_move_dock_length} Y{probe_dock_location_y} F{travel_speed}
+        {% elif probe_before_dock_position == 'right' %}
+            G1 X{probe_dock_location_x + probe_move_dock_length} Y{probe_dock_location_y} F{travel_speed}
+        {% elif probe_before_dock_position == 'front' %}
+            G1 X{probe_dock_location_x} Y{probe_dock_location_y - probe_move_dock_length} F{travel_speed}
+        {% elif probe_before_dock_position == 'back' %}
+            G1 X{probe_dock_location_x} Y{probe_dock_location_y + probe_move_dock_length} F{travel_speed}
         {% else %}
-            { action_raise_error("variable_probe_move_to_attach is incorrectly set!") }
+            { action_raise_error("variable_probe_before_dock_position is incorrectly set!") }
         {% endif %}
         
         # Drop Probe to Probe location
         G1 X{probe_dock_location_x} Y{probe_dock_location_y} F{probe_dock_speed}
         
         # Get the probe out of the dock
-        {% if probe_move_to_detach == 'left' %}
-            G1 X{probe_dock_location_x - probe_move_detach_length} Y{probe_dock_location_y} F{probe_dock_speed}
-        {% elif probe_move_to_detach == 'right' %}
-            G1 X{probe_dock_location_x + probe_move_detach_length} Y{probe_dock_location_y} F{probe_dock_speed}
-        {% elif probe_move_to_detach == 'front' %}
-            G1 X{probe_dock_location_x} Y{probe_dock_location_y + probe_move_detach_length} F{probe_dock_speed}
-        {% elif probe_move_to_detach == 'back' %}
-            G1 X{probe_dock_location_x} Y{probe_dock_location_y - probe_move_detach_length} F{probe_dock_speed}
+        {% if probe_after_dock_position == 'left' %}
+            G1 X{probe_dock_location_x - probe_move_dock_length} Y{probe_dock_location_y} F{probe_dock_speed}
+        {% elif probe_after_dock_position == 'right' %}
+            G1 X{probe_dock_location_x + probe_move_dock_length} Y{probe_dock_location_y} F{probe_dock_speed}
+        {% elif probe_after_dock_position == 'front' %}
+            G1 X{probe_dock_location_x} Y{probe_dock_location_y - probe_move_dock_length} F{probe_dock_speed}
+        {% elif probe_after_dock_position == 'back' %}
+            G1 X{probe_dock_location_x} Y{probe_dock_location_y + probe_move_dock_length} F{probe_dock_speed}
         {% else %}
-            { action_raise_error("variable_probe_move_to_detach is incorrectly set!") }
+            { action_raise_error("variable_probe_after_dock_position is incorrectly set!") }
         {% endif %}
 
         G4 P500

--- a/macros/probing/dockable_probe.cfg
+++ b/macros/probing/dockable_probe.cfg
@@ -55,6 +55,35 @@ description: Locks probe state
 gcode:
     SET_GCODE_VARIABLE MACRO=_PROBE_VARIABLES VARIABLE=probe_lock VALUE={ True }
 
+[gcode_macro _PROBE_MOVE_TO]
+description: positioning toolhead for dock/attach operation
+gcode: 
+
+    {% set location  = params.LOCATION|default('') %}
+    {% set distance  = params.DISTANCE|default(0) %}
+    {% set speed  = params.MOVE_SPEED|default(0) %}
+
+    {% set probe_dock_location_x, probe_dock_location_y = printer["gcode_macro _USER_VARIABLES"].probe_dock_location_xy|map('float') %}
+
+
+    _ENTRY_POINT FUNCTION=_PROBE_MOVE_TO
+    # define dict for location
+    {% set location_factor ={   'left'  : { 'x': -1, 'y':  0 },
+                                'right' : { 'x':  1, 'y':  0 },
+                                'front' : { 'x':  0, 'y': -1 },
+                                'back'  : { 'x':  0, 'y':  1 },
+                                'dock'  : { 'x':  0, 'y':  0 }
+                            } %}
+
+    {% if location_factor[location] is defined %}
+        G1 X{probe_dock_location_x + location_factor[location].x * distance} Y{probe_dock_location_y + location_factor[location].y * distance} F{speed}
+    {% else %}
+        { action_raise_error("LOCATION is incorrectly set!") }
+    {% endif %}
+
+
+    _EXIT_POINT FUNCTION=_PROBE_MOVE_TO
+
 
 [gcode_macro ATTACH_PROBE]
 description: Attaches probe
@@ -79,6 +108,8 @@ gcode:
     {% set travel_speed = printer["gcode_macro _USER_VARIABLES"].travel_speed * 60 %}
     {% set z_drop_speed = printer["gcode_macro _USER_VARIABLES"].z_drop_speed * 60 %}
 
+
+
     _ENTRY_POINT FUNCTION=ATTACH_PROBE
 
     # if x and y are not homed
@@ -100,33 +131,14 @@ gcode:
         {% endif %}
 
         # Probe entry location
-        {% if probe_before_attach_position == 'left' %}
-            G1 X{probe_dock_location_x - probe_move_attach_length} Y{probe_dock_location_y} F{travel_speed}
-        {% elif probe_before_attach_position == 'right' %}
-            G1 X{probe_dock_location_x + probe_move_attach_length} Y{probe_dock_location_y} F{travel_speed}
-        {% elif probe_before_attach_position == 'front' %}
-            G1 X{probe_dock_location_x} Y{probe_dock_location_y - probe_move_attach_length} F{travel_speed}
-        {% elif probe_before_attach_position == 'back' %}
-            G1 X{probe_dock_location_x} Y{probe_dock_location_y + probe_move_attach_length} F{travel_speed}
-        {% else %}
-            { action_raise_error("variable_probe_before_attach_position is incorrectly set!") }
-        {% endif %}
-        
+        _PROBE_MOVE_TO LOCATION={probe_before_attach_position} DISTANCE={probe_move_attach_length} SPEED={travel_speed}
+
         # Pickup from Probe location
-        G1 X{probe_dock_location_x} Y{probe_dock_location_y} F{probe_dock_speed}
+        _PROBE_MOVE_TO LOCATION='dock' SPEED={probe_dock_speed}
         
         # Get the probe out of the dock
-        {% if probe_after_attach_position == 'left' %}
-            G1 X{probe_dock_location_x - probe_move_attach_length} Y{probe_dock_location_y} F{probe_dock_speed}
-        {% elif probe_after_attach_position == 'right' %}
-            G1 X{probe_dock_location_x + probe_move_attach_length} Y{probe_dock_location_y} F{probe_dock_speed}
-        {% elif probe_after_attach_position == 'front' %}
-            G1 X{probe_dock_location_x} Y{probe_dock_location_y - probe_move_attach_length} F{probe_dock_speed}
-        {% elif probe_after_attach_position == 'back' %}
-            G1 X{probe_dock_location_x} Y{probe_dock_location_y + probe_move_attach_length} F{probe_dock_speed}
-        {% else %}
-            { action_raise_error("variable_probe_after_attach_position is incorrectly set!") }
-        {% endif %}
+        _PROBE_MOVE_TO LOCATION={probe_after_attach_position} DISTANCE={probe_move_attach_length} SPEED={probe_dock_speed}
+
 
         _CHECK_PROBE action=attach
 
@@ -192,34 +204,15 @@ gcode:
             G0 Z{probe_min_z_travel} F{z_drop_speed}
         {% endif %}
 
-        # Probe entry location
-        {% if probe_before_dock_position == 'left' %}
-            G1 X{probe_dock_location_x - probe_move_dock_length} Y{probe_dock_location_y} F{travel_speed}
-        {% elif probe_before_dock_position == 'right' %}
-            G1 X{probe_dock_location_x + probe_move_dock_length} Y{probe_dock_location_y} F{travel_speed}
-        {% elif probe_before_dock_position == 'front' %}
-            G1 X{probe_dock_location_x} Y{probe_dock_location_y - probe_move_dock_length} F{travel_speed}
-        {% elif probe_before_dock_position == 'back' %}
-            G1 X{probe_dock_location_x} Y{probe_dock_location_y + probe_move_dock_length} F{travel_speed}
-        {% else %}
-            { action_raise_error("variable_probe_before_dock_position is incorrectly set!") }
-        {% endif %}
+         # Probe entry location
+        _PROBE_MOVE_TO LOCATION={probe_before_dock_position} DISTANCE={probe_move_dock_length} SPEED={travel_speed}
+
+        # Pickup from Probe location
+        _PROBE_MOVE_TO LOCATION='dock' SPEED={probe_dock_speed}
         
-        # Drop Probe to Probe location
-        G1 X{probe_dock_location_x} Y{probe_dock_location_y} F{probe_dock_speed}
-        
-        # Get the probe out of the dock
-        {% if probe_after_dock_position == 'left' %}
-            G1 X{probe_dock_location_x - probe_move_dock_length} Y{probe_dock_location_y} F{probe_dock_speed}
-        {% elif probe_after_dock_position == 'right' %}
-            G1 X{probe_dock_location_x + probe_move_dock_length} Y{probe_dock_location_y} F{probe_dock_speed}
-        {% elif probe_after_dock_position == 'front' %}
-            G1 X{probe_dock_location_x} Y{probe_dock_location_y - probe_move_dock_length} F{probe_dock_speed}
-        {% elif probe_after_dock_position == 'back' %}
-            G1 X{probe_dock_location_x} Y{probe_dock_location_y + probe_move_dock_length} F{probe_dock_speed}
-        {% else %}
-            { action_raise_error("variable_probe_after_dock_position is incorrectly set!") }
-        {% endif %}
+        # Get detach probe
+        _PROBE_MOVE_TO LOCATION={probe_after_dock_position} DISTANCE={probe_move_dock_length} SPEED={probe_dock_speed}
+
 
         G4 P500
         _CHECK_PROBE action=dock

--- a/macros/probing/dockable_probe.cfg
+++ b/macros/probing/dockable_probe.cfg
@@ -59,14 +59,13 @@ gcode:
 description: positioning toolhead for dock/attach operation
 gcode: 
 
-    {% set location  = params.LOCATION|default('') %}
-    {% set distance  = params.DISTANCE|default(0) %}
-    {% set speed  = params.MOVE_SPEED|default(0) %}
+    {% set location  = params.LOCATION|default('')|string %}
+    {% set distance  = params.DISTANCE|default(0)|float %}
+    {% set speed  = params.SPEED|default(0)|float %}
 
     {% set probe_dock_location_x, probe_dock_location_y = printer["gcode_macro _USER_VARIABLES"].probe_dock_location_xy|map('float') %}
 
 
-    _ENTRY_POINT FUNCTION=_PROBE_MOVE_TO
     # define dict for location
     {% set location_factor ={   'left'  : { 'x': -1, 'y':  0 },
                                 'right' : { 'x':  1, 'y':  0 },
@@ -81,8 +80,6 @@ gcode:
         { action_raise_error("LOCATION is incorrectly set!") }
     {% endif %}
 
-
-    _EXIT_POINT FUNCTION=_PROBE_MOVE_TO
 
 
 [gcode_macro ATTACH_PROBE]

--- a/macros/variables.cfg
+++ b/macros/variables.cfg
@@ -23,23 +23,23 @@ variable_probe_min_z_travel: 15
 # Position of the probe dock
 variable_probe_dock_location_xy: 246.7, 306
 
-# Movement direction to attach probe
-# when the toolhead is already in the dock
-variable_probe_move_to_attach: "back"
-variable_probe_move_attach_length: 20
+# Positions of the toolhead when docking/undocking the probe
+# See diagram below for help
+variable_probe_before_attach_position: "front"
+variable_probe_after_attach_position : "front"
+variable_probe_before_dock_position : "front" # generaly same as probe_after_attach_position
+variable_probe_after_dock_position : "left"
 
-# Movement direction to detach probe
-# when the toolhead is already in the dock
-variable_probe_move_to_detach: "left"
-variable_probe_move_detach_length: 50
+variable_probe_move_attach_length: 20
+variable_probe_move_dock_length: 50
 
 #    Y
 #    ^ 
-#    |         front
+#    |          back
 #    |           ^
 #    |   left  < O >  right
 #    |           v
-#    |          back
+#    |         front
 #    |_ _ _ _ _ _ _ _ _ _ _ _> X
 
 


### PR DESCRIPTION
The goal is to allow the management of the probe to be more flexible by also setting the entry point for each dock/undock movements. This to solve #14 

Now in the variables.cfg file, it's set as:
```
# Position of the probe dock
variable_probe_dock_location_xy: 246.7, 306

# Positions of the toolhead when docking/undocking the probe
# See diagram below for help
variable_probe_before_attach_position: "front"
variable_probe_after_attach_position : "front"
variable_probe_before_dock_position : "front" # generaly same as probe_after_attach_position
variable_probe_after_dock_position : "left"

variable_probe_move_attach_length: 20
variable_probe_move_dock_length: 50
```