### PR TITLE
add-option-in-start-end-print

### DIFF
--- a/macros/print_base/end_print.cfg
+++ b/macros/print_base/end_print.cfg
@@ -1,6 +1,8 @@
 [gcode_macro END_PRINT]
 description: Stop the print and filter the atmosphere for 10min before shuting down
 gcode:
+    {% set disable_motors_in_end_print = printer["gcode_macro _USER_VARIABLES"].disable_motors_in_end_print %}
+
     M400
 
     PARK
@@ -10,7 +12,10 @@ gcode:
     TURN_OFF_HEATERS
     M107
     BED_MESH_CLEAR
-    M84
+    {% if disable_motors_in_end_print %}
+        M84
+    {% endif %}	
+
 
     # If a filter is connected, filter the air at full power
     # for a couple of min before stopping everything

--- a/macros/print_base/start_print.cfg
+++ b/macros/print_base/start_print.cfg
@@ -27,6 +27,7 @@ gcode:
     {% set purge_and_brush_enabled = printer["gcode_macro _USER_VARIABLES"].purge_and_brush_enabled %}
     {% set chamber_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].chamber_temperature_sensor_enabled %}
     {% set zcalib_plugin_enabled = printer["gcode_macro _USER_VARIABLES"].zcalib_plugin_enabled %}
+    {% set force_homing_in_start_print = printer["gcode_macro _USER_VARIABLES"].force_homing_in_start_print %}
 
     {% set max_x = printer.toolhead.axis_maximum.x|float %}
     {% set max_y = printer.toolhead.axis_maximum.y|float %}
@@ -41,7 +42,12 @@ gcode:
 
     # 1 ----- HOMING ------------------------------------------
     # Home if not already homed and park the head near the center front
-    _CG28
+    {% if force_homing_in_start_print %}
+         G28
+    {% else %}
+         _CG28
+    {% endif %}	
+
     G0 X{max_x|int / 2} Y{max_y|int / 3} Z50 F{St}
 
 
@@ -83,7 +89,7 @@ gcode:
 
 
     # 4 ----- QUAD GANTRY LEVELING -----------------------------
-    {% if printer.quad_gantry_level.applied|lower == 'false' %}
+    {% if printer.quad_gantry_level.applied|lower == 'false' or force_homing_in_start_print %}
         {% if verbose %}
             RESPOND MSG="QGL..."
         {% endif %}

--- a/macros/variables.cfg
+++ b/macros/variables.cfg
@@ -107,7 +107,11 @@ variable_zcalib_plugin_enabled: True
 #    - Set the machine z_endstop coordinates here !!!
 variable_zendstop_position: -1, -1 # Used only if variable_zcalib_plugin_enabled is set to false !!!
 
+# To always make a full homing and QGL in start print
+variable_force_homing_in_start_print: False
 
+# To disable motors in end print
+variable_disable_motors_in_end_print: True
 
 # Do not remove the next line
 gcode:

--- a/macros/variables.cfg
+++ b/macros/variables.cfg
@@ -45,12 +45,15 @@ variable_probe_move_dock_length: 50
 
 
 #################################################
-# Homing and print start variables
+# Homing, start_print and end_print variables
 #################################################
 
-# As I use the Z_calibration plugin, the physical Z
-# endstop position is defined in the [z_calibration]
-# section that you can find in hardware/probe.cfg
+# For the physical Z endstop pin position, please see in the other
+# options bellow as it's needed only if you don't use the automatic
+# z_calibration plugin (that is by the way fully optional)
+
+# Force always a full homing and QGL during the START_PRINT macro
+variable_force_homing_in_start_print: False
 
 # Z hop before homing to avoid grinding
 # the bed due to the gantry sag
@@ -72,6 +75,9 @@ variable_prime_line_xy: 2.5, 20
 
 # Park position used when pause, end_print, etc...
 variable_park_position_xy: 20, 307
+
+# Automatically disable motors in the END_PRINT macro
+variable_disable_motors_in_end_print: True
 
 
 ################################################
@@ -107,11 +113,7 @@ variable_zcalib_plugin_enabled: True
 #    - Set the machine z_endstop coordinates here !!!
 variable_zendstop_position: -1, -1 # Used only if variable_zcalib_plugin_enabled is set to false !!!
 
-# To always make a full homing and QGL in start print
-variable_force_homing_in_start_print: False
 
-# To disable motors in end print
-variable_disable_motors_in_end_print: True
 
 # Do not remove the next line
 gcode:


### PR DESCRIPTION
# To always make a full homing and QGL in start print
`variable_force_homing_in_start_print: False`

# To disable motors in end print
`variable_disable_motors_in_end_print: True`