### PR TITLE
Enable vibration calibration in other axis

### DIFF
--- a/macros/calibration/vibr_calibrate_02.cfg
+++ b/macros/calibration/vibr_calibrate_02.cfg
@@ -45,6 +45,7 @@ gcode:
     # PARAMETERS
     #
     {% set size = params.SIZE|default(60)|int %} # size of the area where the movements are done
+    {% set direction = params.DIRECTION|default(0)|int %} # 0 for XY, 1 for AB, 2 for ABXY, 3-6 for A/B/X/Y
     {% set z_height = params.Z_HEIGHT|default(20)|int %} # z height to put the toolhead before starting the movements
     {% set verbose = params.VERBOSE|default(true) %} # Wether to log the current speed in the console
     
@@ -81,7 +82,22 @@ gcode:
     {% endif %}
 
     G90
-    G1 X{mid_x - size / 2} Y{mid_y - size / 2} Z{z_height} F{feedrate_travel}
+    G1 Z{z_height}
+    {% if direction == 0 %} # XY
+        G1 X{mid_x - size / 2} Y{mid_y - size / 2} F{feedrate_travel}    # front left
+    {% elif direction == 1 %} # AB
+        G1 X{mid_x} Y{mid_y} F{feedrate_travel}                          # in the middle
+    {% elif direction == 2 %} # ABXY
+        G1 X{mid_x - size / 2} Y{mid_y + size / 2} F{feedrate_travel}    # back left
+    {% elif direction == 3 %} # A
+        G1 X{mid_x + size / 2} Y{mid_y + size / 2} F{feedrate_travel}    # back right
+    {% elif direction == 4 %} # B
+        G1 X{mid_x - size / 2} Y{mid_y + size / 2} F{feedrate_travel}    # back left
+    {% elif direction == 5 %} # X
+        G1 X{mid_x - size / 2} Y{mid_y} F{feedrate_travel}    # mid left
+    {% elif direction == 6 %} # Y
+        G1 X{mid_x} Y{mid_y + size / 2} F{feedrate_travel}    # back mid
+    {% endif %}
 
     {% for curr_speed in range(min_speed, max_speed + speed_increment) %}
         {% if (curr_speed - min_speed) % speed_increment == 0 %}
@@ -89,13 +105,53 @@ gcode:
                 RESPOND MSG="Current speed: {(curr_speed / 60)|int} mm/s"
             {% endif %}
 
-            ACCELEROMETER_MEASURE CHIP={accel_chip}
-            G1 X{mid_x + size / 2} F{curr_speed}
-            G1 Y{mid_y + size / 2} F{curr_speed}
-            G1 X{mid_x - size / 2} F{curr_speed}
-            G1 Y{mid_y - size / 2} F{curr_speed}
-            ACCELEROMETER_MEASURE CHIP={accel_chip} NAME=sp{(curr_speed / 60)|int}n1
-            
+            {% if direction == 0 %}
+                ACCELEROMETER_MEASURE CHIP={accel_chip}
+                G1 X{mid_x + size / 2} Y{mid_y - size / 2} F{curr_speed}    # front right
+                G1 X{mid_x + size / 2} Y{mid_y + size / 2} F{curr_speed}    # back right
+                G1 X{mid_x - size / 2} Y{mid_y + size / 2} F{curr_speed}    # back left
+                G1 X{mid_x - size / 2} Y{mid_y - size / 2} F{curr_speed}    # front left
+                ACCELEROMETER_MEASURE CHIP={accel_chip} NAME=sp{(curr_speed / 60)|int}n1
+            {% elif direction == 1 %}
+                ACCELEROMETER_MEASURE CHIP={accel_chip}
+                G1 X{mid_x + size / 2} Y{mid_y - size / 2} F{curr_speed}    # front right
+                G1 X{mid_x - size / 2} Y{mid_y + size / 2} F{curr_speed}    # back left
+                G1 X{mid_x} Y{mid_y} Z{z_height} F{curr_speed}              # back to the middle
+                G1 X{mid_x + size / 2} Y{mid_y + size / 2} F{curr_speed}    # back right
+                G1 X{mid_x - size / 2} Y{mid_y - size / 2} F{curr_speed}    # front left
+                G1 X{mid_x} Y{mid_y} Z{z_height} F{curr_speed}              # back to the middle
+                ACCELEROMETER_MEASURE CHIP={accel_chip} NAME=sp{(curr_speed / 60)|int}n1
+            {% elif direction == 2 %}
+                ACCELEROMETER_MEASURE CHIP={accel_chip}
+                G1 X{mid_x - size / 2} Y{mid_y - size / 2} F{curr_speed}    # front left
+                G1 X{mid_x + size / 2} Y{mid_y - size / 2} F{curr_speed}    # front right
+                G1 X{mid_x - size / 2} Y{mid_y + size / 2} F{curr_speed}    # back left
+                G1 X{mid_x + size / 2} Y{mid_y + size / 2} F{curr_speed}    # back right
+                G1 X{mid_x - size / 2} Y{mid_y - size / 2} F{curr_speed}    # front left
+                G1 X{mid_x - size / 2} Y{mid_y + size / 2} F{curr_speed}    # back left
+                ACCELEROMETER_MEASURE CHIP={accel_chip} NAME=sp{(curr_speed / 60)|int}n1
+            {% elif direction == 3 %}
+                ACCELEROMETER_MEASURE CHIP={accel_chip}
+                G1 X{mid_x - size / 2} Y{mid_y - size / 2} F{curr_speed}    # front left
+                G1 X{mid_x + size / 2} Y{mid_y + size / 2} F{curr_speed}    # back right
+                ACCELEROMETER_MEASURE CHIP={accel_chip} NAME=sp{(curr_speed / 60)|int}n1
+            {% elif direction == 4 %}
+                ACCELEROMETER_MEASURE CHIP={accel_chip}
+                G1 X{mid_x + size / 2} Y{mid_y + size / 2} F{curr_speed}    # back right
+                G1 X{mid_x - size / 2} Y{mid_y + size / 2} F{curr_speed}    # back left
+                ACCELEROMETER_MEASURE CHIP={accel_chip} NAME=sp{(curr_speed / 60)|int}n1
+            {% elif direction == 5 %}
+                ACCELEROMETER_MEASURE CHIP={accel_chip}
+                G1 X{mid_x + size / 2} Y{mid_y} F{curr_speed}    # mid right
+                G1 X{mid_x - size / 2} Y{mid_y} F{curr_speed}    # mid left
+                ACCELEROMETER_MEASURE CHIP={accel_chip} NAME=sp{(curr_speed / 60)|int}n1
+            {% elif direction == 6 %}
+                ACCELEROMETER_MEASURE CHIP={accel_chip}
+                G1 X{mid_x} Y{mid_y - size / 2} F{curr_speed}    # font mid
+                G1 X{mid_x} Y{mid_y + size / 2} F{curr_speed}    # back mid
+                ACCELEROMETER_MEASURE CHIP={accel_chip} NAME=sp{(curr_speed / 60)|int}n1
+            {% endif %}
+
             G4 P300
             M400
         {% endif %}


### PR DESCRIPTION
Thanks for this awesome script and macro! I've been using it to fix some VFA on my v0.1 - I added another input parameter to let me specify different movement patterns for measuring either AB, XY, ABXY, A, B, X or Y.

You're welcome to take this or leave it, or it might be helpful to someone passing through.

--- 

Here are my results demonstrating the value. The A motion resonates at a different frequency to B, X and Y. Tomorrow I'll be checking all the bearings in that belt path 😉 

## A-axis
![vibrations_20221005_234305](https://user-images.githubusercontent.com/3055120/194184074-f64cccd8-356e-4767-8a7b-2cf93b156d45.png)

## B-axis
![vibrations_20221005_235447](https://user-images.githubusercontent.com/3055120/194184091-56d25f3c-0269-4a55-aae0-e95543ee98ef.png)

## X-Axis
![vibrations_20221006_000230](https://user-images.githubusercontent.com/3055120/194184115-1439b881-d6d2-47b1-8e41-538730e89f9b.png)

## Y-Axis
![vibrations_20221006_000937](https://user-images.githubusercontent.com/3055120/194184140-5e0172d3-9f5f-40d6-8074-0af183ef506d.png)

## ABXY
![vibrations_20221006_002545](https://user-images.githubusercontent.com/3055120/194184163-2ac839c9-a96e-4dcd-aa0d-c766efb6b23d.png)


