### PR TITLE
Refacto:  multiple mcu configuration management

### DIFF
--- a/config/hardware/addons/accelerometers/adxl345.cfg
+++ b/config/hardware/addons/accelerometers/adxl345.cfg
@@ -1,6 +1,6 @@
 [adxl345]
 spi_bus: ssp1
-cs_pin: z:ADXL_CS
+cs_pin: ADXL_CS
 axes_map: -z,y,x
 
 [resonance_tester]

--- a/config/hardware/addons/filters/nevermore_filter.cfg
+++ b/config/hardware/addons/filters/nevermore_filter.cfg
@@ -9,7 +9,7 @@ gcode:
 
 
 [fan_generic filter]
-pin: z:FILTER_FAN
+pin: FILTER_FAN
 max_power: 1.0
 kick_start_time: 0.250
 off_below: 0.30

--- a/config/hardware/addons/lights/fcob_white.cfg
+++ b/config/hardware/addons/lights/fcob_white.cfg
@@ -9,7 +9,7 @@ gcode:
 
 
 [output_pin caselight]
-pin: z:LIGHT_OUTPUT
+pin: LIGHT_OUTPUT
 pwm: true
 value: 0
 scale: 100

--- a/config/hardware/addons/temperature_sensors/cabinet_temp.cfg
+++ b/config/hardware/addons/temperature_sensors/cabinet_temp.cfg
@@ -1,3 +1,3 @@
 [temperature_sensor ElectricalCabinet]
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: z:ELECTRICAL_CABINET_TEMPERATURE
+sensor_pin: ELECTRICAL_CABINET_TEMPERATURE

--- a/config/hardware/base/Z/V2.4_galileo_z.cfg
+++ b/config/hardware/base/Z/V2.4_galileo_z.cfg
@@ -1,8 +1,8 @@
 [stepper_z]
-step_pin: z:Z_STEP
-dir_pin: z:Z_DIR
-enable_pin: !z:Z_ENABLE
-endstop_pin: z:Z_STOP
+step_pin: Z_STEP
+dir_pin: Z_DIR
+enable_pin: !Z_ENABLE
+endstop_pin: Z_STOP
 rotation_distance: 40
 gear_ratio: 6:1
 microsteps: 32
@@ -14,7 +14,7 @@ second_homing_speed: 8
 homing_retract_dist: 3.0
 
 [tmc2209 stepper_z]
-uart_pin: z:Z_TMCUART
+uart_pin: Z_TMCUART
 interpolate: False
 run_current: 0.8
 sense_resistor: 0.110
@@ -22,15 +22,15 @@ stealthchop_threshold: 0
 # stealthchop_threshold: 99999
 
 [stepper_z1]
-step_pin: z:Z1_STEP
-dir_pin: !z:Z1_DIR
-enable_pin: !z:Z1_ENABLE
+step_pin: Z1_STEP
+dir_pin: !Z1_DIR
+enable_pin: !Z1_ENABLE
 rotation_distance: 40
 gear_ratio: 6:1
 microsteps: 32
 
 [tmc2209 stepper_z1]
-uart_pin: z:Z1_TMCUART
+uart_pin: Z1_TMCUART
 interpolate: False
 run_current: 0.8
 sense_resistor: 0.110
@@ -38,15 +38,15 @@ stealthchop_threshold: 0
 # stealthchop_threshold: 99999
 
 [stepper_z2]
-step_pin: z:Z2_STEP
-dir_pin: z:Z2_DIR
-enable_pin: !z:Z2_ENABLE
+step_pin: Z2_STEP
+dir_pin: Z2_DIR
+enable_pin: !Z2_ENABLE
 rotation_distance: 40
 gear_ratio: 6:1
 microsteps: 32
 
 [tmc2209 stepper_z2]
-uart_pin: z:Z2_TMCUART
+uart_pin: Z2_TMCUART
 interpolate: False
 run_current: 0.8
 sense_resistor: 0.110
@@ -54,15 +54,15 @@ stealthchop_threshold: 0
 # stealthchop_threshold: 99999
 
 [stepper_z3]
-step_pin: z:Z3_STEP
-dir_pin: !z:Z3_DIR
-enable_pin: !z:Z3_ENABLE
+step_pin: Z3_STEP
+dir_pin: !Z3_DIR
+enable_pin: !Z3_ENABLE
 rotation_distance: 40
 gear_ratio: 6:1
 microsteps: 32
 
 [tmc2209 stepper_z3]
-uart_pin: z:Z3_TMCUART
+uart_pin: Z3_TMCUART
 interpolate: False
 run_current: 0.8
 sense_resistor: 0.110

--- a/config/hardware/base/fans/controller_fan.cfg
+++ b/config/hardware/base/fans/controller_fan.cfg
@@ -1,5 +1,5 @@
 [heater_fan controller_fan]
-pin: z:P2.4
+pin: CONTROLLER_FAN
 kick_start_time: 0.5
 heater: heater_bed
 heater_temp: 45.0

--- a/config/hardware/base/fans/exhaust_fan.cfg
+++ b/config/hardware/base/fans/exhaust_fan.cfg
@@ -1,5 +1,5 @@
 [heater_fan exhaust_fan]
-pin: z:P2.7
+pin: FILTER_FAN
 max_power: 1.0
 shutdown_speed: 0.0
 kick_start_time: 5.0

--- a/config/hardware/base/heated_bed.cfg
+++ b/config/hardware/base/heated_bed.cfg
@@ -1,7 +1,7 @@
 [heater_bed]
-heater_pin: z:BED_HEATER
+heater_pin: BED_HEATER
 sensor_type: NTC 100K MGB18-104F39050L32
-sensor_pin: z:BED_TEMPERATURE
+sensor_pin: BED_TEMPERATURE
 max_power: 0.6
 min_temp: 0
 max_temp: 120

--- a/config/hardware/base/probe.cfg
+++ b/config/hardware/base/probe.cfg
@@ -2,7 +2,7 @@
 [include ../../../macros/base/probing/overides/probe_base.cfg]
 
 [probe]
-pin: ^z:PROBE_INPUT
+pin: ^PROBE_INPUT
 x_offset: 0
 y_offset: 19.75
 z_offset: 6.42

--- a/config/mcus/_multiple-mcu-pin-override.cfg
+++ b/config/mcus/_multiple-mcu-pin-override.cfg
@@ -1,0 +1,69 @@
+# Required file when using a multiple mcus configuration
+# This will override all earlier section definitions.
+# This file needs to be inculde after all other files containing pin defenitions.
+
+## You need to uncomment enabled addons
+
+[stepper_z]
+step_pin: z:Z_STEP
+dir_pin: z:Z_DIR
+enable_pin: !z:Z_ENABLE
+endstop_pin: z:Z_STOP
+
+[tmc2209 stepper_z]
+uart_pin: z:Z_TMCUART
+
+[stepper_z1]
+step_pin: z:Z1_STEP
+dir_pin: !z:Z1_DIR
+enable_pin: !z:Z1_ENABLE
+
+[tmc2209 stepper_z1]
+uart_pin: z:Z1_TMCUART
+
+[stepper_z2]
+step_pin: z:Z2_STEP
+dir_pin: z:Z2_DIR
+enable_pin: !z:Z2_ENABLE
+
+[tmc2209 stepper_z2]
+uart_pin: z:Z2_TMCUART
+
+[stepper_z3]
+step_pin: z:Z3_STEP
+dir_pin: !z:Z3_DIR
+enable_pin: !z:Z3_ENABLE
+
+[tmc2209 stepper_z3]
+uart_pin: z:Z3_TMCUART
+
+[heater_bed]
+heater_pin: z:BED_HEATER
+sensor_pin: z:BED_TEMPERATURE
+
+[probe]
+pin: ^z:PROBE_INPUT
+
+[heater_fan exhaust_fan]
+pin: z:FILTER_FAN
+
+[heater_fan controller_fan]
+pin: z:CONTROLLER_FAN
+
+# -------- ADDONS --------- #
+
+## ADXL345
+# [adxl345]
+# cs_pin: z:ADXL_CS
+
+## NEVERMORE FILTER
+# [fan_generic filter]
+# pin: z:FILTER_FAN
+
+## FCOB LIGHT
+# [output_pin caselight]
+# pin: z:LIGHT_OUTPUT
+
+## CABINET TEMP
+# [temperature_sensor ElectricalCabinet]
+# sensor_pin: z:ELECTRICAL_CABINET_TEMPERATURE

--- a/printer.cfg
+++ b/printer.cfg
@@ -52,6 +52,7 @@
 
 # [include config/hardware/addons/ercf.cfg]
 
+[include config/mcus/_multiple-mcu-pin-override.cfg] # required for multiple mcus configuration
 
 ###################################
 ### KLIPPER SOFTWARE COMPONENTS ###


### PR DESCRIPTION
This is a proposition on how to handle the pin_aliases for multiple mcu config.

WHAT THE GOAL OF THIS PR
As the most common case is to have a printer whit only one controller_board(mcu) and In order to make the most generic config as possible, the 'default' pin_aliases registered in the different files and sections should be used without prefix (case of multiple mcu). 

HOW IT WORKS.
All default pin-aliases are declared without prefix.
For the case of multiple mcu, a new file can be included in the printer.cfg. It contains all sections that contain a pin declaration with a prefix. As this file is called after all the previous 'default' pin déclarations. This should in theory  override them.

!!! This has not been tested as I don't have a multiple mcu config !!!


WHAT HAS BEEN MODIFIED
- remove all prefixed pin_aliases from config/
- create _multiple_mcu_pin_override.cfg file and 
- add an include in printer.cfg

- FIX: specific mcu pin called in some fan section replaced with their corresponding pin_aliases.