### PR TITLE
Add support for ADXL on RPi, USB, Canboard

### DIFF
--- a/config/hardware/addons/accelerometers/adxl345_ebb.cfg
+++ b/config/hardware/addons/accelerometers/adxl345_ebb.cfg
@@ -1,8 +1,8 @@
 [adxl345]
-cs_pin: EBBCan: ADXL_CS
-spi_software_sclk_pin: EBBCan: ADXL_SCLK
-spi_software_mosi_pin: EBBCan: ADXL_MOSI
-spi_software_miso_pin: EBBCan: ADXL_MISO
+cs_pin: toolhead: ADXL_CS
+spi_software_sclk_pin: toolhead: ADXL_SCLK
+spi_software_mosi_pin: toolhead: ADXL_MOSI
+spi_software_miso_pin: toolhead: ADXL_MISO
 axes_map: x,y,z
 
 [resonance_tester]

--- a/config/hardware/addons/accelerometers/adxl345_ebb.cfg
+++ b/config/hardware/addons/accelerometers/adxl345_ebb.cfg
@@ -1,8 +1,8 @@
 [adxl345]
-cs_pin: toolhead: ADXL_CS
-spi_software_sclk_pin: toolhead: ADXL_SCLK
-spi_software_mosi_pin: toolhead: ADXL_MOSI
-spi_software_miso_pin: toolhead: ADXL_MISO
+cs_pin: toolhead:ADXL_CS
+spi_software_sclk_pin: toolhead:ADXL_SCLK
+spi_software_mosi_pin: toolhead:ADXL_MOSI
+spi_software_miso_pin: toolhead:ADXL_MISO
 axes_map: x,y,z
 
 [resonance_tester]

--- a/config/hardware/addons/accelerometers/adxl345_ebb.cfg
+++ b/config/hardware/addons/accelerometers/adxl345_ebb.cfg
@@ -1,0 +1,17 @@
+[adxl345]
+cs_pin: EBBCan: ADXL_CS
+spi_software_sclk_pin: EBBCan: ADXL_SCLK
+spi_software_mosi_pin: EBBCan: ADXL_MOSI
+spi_software_miso_pin: EBBCan: ADXL_MISO
+axes_map: x,y,z
+
+[resonance_tester]
+accel_chip: adxl345
+probe_points:
+    150,150,20
+
+
+# Include the vibr_calibrat_xx macros to unlock them when
+# an accelerometer is installed on the machine
+[include ../../../../macros/addons/calibration/vibr_calibrate_01.cfg]
+[include ../../../../macros/addons/calibration/vibr_calibrate_02.cfg]

--- a/config/hardware/addons/accelerometers/adxl345_rpi.cfg
+++ b/config/hardware/addons/accelerometers/adxl345_rpi.cfg
@@ -1,0 +1,17 @@
+[mcu rpi]
+serial: /tmp/klipper_host_mcu
+
+[adxl345]
+cs_pin: rpi:none
+axes_map: -z,y,x
+
+[resonance_tester]
+accel_chip: adxl345
+probe_points:
+    150,150,20
+
+
+# Include the vibr_calibrat_xx macros to unlock them when
+# an accelerometer is installed on the machine
+[include ../../../../macros/addons/calibration/vibr_calibrate_01.cfg]
+[include ../../../../macros/addons/calibration/vibr_calibrate_02.cfg]

--- a/config/hardware/addons/accelerometers/adxl345_sht.cfg
+++ b/config/hardware/addons/accelerometers/adxl345_sht.cfg
@@ -1,0 +1,15 @@
+[adxl345]
+cs_pin: SHTCan:ADXL_CS
+spi_bus: spi1
+axes_map: x,y,z
+
+[resonance_tester]
+accel_chip: adxl345
+probe_points:
+    150,150,20
+
+
+# Include the vibr_calibrat_xx macros to unlock them when
+# an accelerometer is installed on the machine
+[include ../../../../macros/addons/calibration/vibr_calibrate_01.cfg]
+[include ../../../../macros/addons/calibration/vibr_calibrate_02.cfg]

--- a/config/hardware/addons/accelerometers/adxl345_sht.cfg
+++ b/config/hardware/addons/accelerometers/adxl345_sht.cfg
@@ -1,5 +1,5 @@
 [adxl345]
-cs_pin: SHTCan:ADXL_CS
+cs_pin: toolhead:ADXL_CS
 spi_bus: spi1
 axes_map: x,y,z
 

--- a/config/hardware/addons/accelerometers/adxl345_usb.cfg
+++ b/config/hardware/addons/accelerometers/adxl345_usb.cfg
@@ -1,8 +1,11 @@
-[mcu rpi]
-serial: /tmp/klipper_host_mcu
+# USB support for RPi pico and KUSBA V2
+# Edit the serial line with the correct address.
+[mcu adxl]
+serial: /dev/serial/by-id/xxx
 
 [adxl345]
-cs_pin: rpi:none
+cs_pin: adxl:gpio1
+spi_bus: spi0a
 axes_map: -z,y,x
 
 [resonance_tester]

--- a/config/hardware/addons/accelerometers/adxl345_usb.cfg
+++ b/config/hardware/addons/accelerometers/adxl345_usb.cfg
@@ -1,0 +1,17 @@
+[mcu rpi]
+serial: /tmp/klipper_host_mcu
+
+[adxl345]
+cs_pin: rpi:none
+axes_map: -z,y,x
+
+[resonance_tester]
+accel_chip: adxl345
+probe_points:
+    150,150,20
+
+
+# Include the vibr_calibrat_xx macros to unlock them when
+# an accelerometer is installed on the machine
+[include ../../../../macros/addons/calibration/vibr_calibrate_01.cfg]
+[include ../../../../macros/addons/calibration/vibr_calibrate_02.cfg]

--- a/printer.cfg
+++ b/printer.cfg
@@ -50,6 +50,10 @@
 # [include config/hardware/addons/filament_sensors/runout_sensor.cfg] #TODO: create file
 
 [include config/hardware/addons/accelerometers/adxl345.cfg]
+# [include config/hardware/addons/accelerometers/adxl345_rpi.cfg]
+# [include config/hardware/addons/accelerometers/adxl345_usb.cfg]
+# [include config/hardware/addons/accelerometers/adxl345_ebb.cfg]
+# [include config/hardware/addons/accelerometers/adxl345_sht.cfg]
 
 [include config/hardware/addons/filters/nevermore_filter.cfg]
 


### PR DESCRIPTION
Hi,
All is in title ;-)

BTW, you should consider to use POINT parameter with TEST_RESONANCES in vibr_calibrate_01.cfg in order to test in the center of the bed or some points set in `variables.cfg` regardless of the `probe_points` in `resonance_tester` section.

What are you thoughts about this? 