### PR TITLE
Adaptive bed mesh v3

### DIFF
--- a/doc/features/adaptive_bed_mesh.md
+++ b/doc/features/adaptive_bed_mesh.md
@@ -24,14 +24,14 @@ If you installed and use the full config folder of this github repository, this 
 If you want to install it to your own custom config, here is the way to go:
   1. Copy the [adaptive_bed_mesh.cfg](./../../macros/addons/adaptive_bed_mesh.cfg) macro file directly into your own config and include it.
   2. The macro needs the bounding box of the first layer to be able to compute a mesh on this surface. There is now two way to get it. Choose the one you prefer for your setup:
-    
-      - **The first way is the most easy** as you have nothing to do beside activating the `[exclude_object]` mechanisms of Moonraker and Klipper. To proceed, you can follow the excellent [Exclude Objects guide from the Mainsail team](https://docs.mainsail.xyz/features/exclude_objects). Then you can go to step 3.
+
+      - **Method 1. It's the most easy way** as you have nothing to do beside activating the `[exclude_object]` mechanisms of Moonraker and Klipper. To proceed, you can follow the excellent [Exclude Objects guide from the Mainsail team](https://docs.mainsail.xyz/features/exclude_objects). Then you can go to step 3.
       
         This method of extracting data was derived from [Kyleisah KAMP repository](https://github.com/kyleisah/Klipper-Adaptive-Meshing-Purging). Many thanks to him for the idea!
       
         Please note that only G-Code files that have been prepared accordingly will be able to use the adaptive mesh feature. For old and unprocessed files, a normal bed mesh will be automatically applied instead.
       
-      - **If you want to do it the manual way**, you will need to change some settings in your slicer:
+      - **Method 2. If you want to do it the manual way**, you will need to change some settings in your slicer:
 
         - **SuperSlicer** is easy. Just change your custom g_code PRINT_START macro to add the SIZE argument like this (everything should be on one line !):
 
@@ -50,6 +50,8 @@ If you want to install it to your own custom config, here is the way to go:
           ```
           PRINT_START [all your own things...] SIZE=%MINX%_%MINY%_%MAXX%_%MAXY%
           ```
+
+> Please note that using the `[exclude_object]` tags (method 1) is a little bit less precise than using the original "SIZE" parameter (method 2) as the `[exclude_object]` tags are using the full parts sizes (not only the first layer). So if you do a part with large overhangs, it will do a large mesh using the tags but will only mesh the base of the part with the SIZE parameter. Also, if you add a skirt around the parts, there is no tags associated to this and the mesh can be a little bit smaller and lead to bad adhesion of the skirt in case of a very bad "taco" bed (like on an Ender3 or CR10 style printers). So my advice is: use the [exclude_object] tags method for a new installation as it's much more easier to install. But if you are updating from an older version of the macro, continue to use the SIZE parameter as the hard part is already done and will still work.
 
   3. In klipper, if it's not already the case, add and configure a `[bed_mesh]` for your machine. This will be the base on which my macro compute the new adaptive bed mesh. Keep in mind that you can (and should) push the precision a little bit further: do not hesistate to go with a mesh of 9x9 (or even more) as with my adaptive bed mesh, not all the points will be probed for smaller parts.
 

--- a/doc/features/adaptive_bed_mesh.md
+++ b/doc/features/adaptive_bed_mesh.md
@@ -8,12 +8,12 @@ The adaptive bed mesh is one of the most known macro of this config. It's almost
 Sometime I print small parts, sometime I print full plates and I like to get a precise bed_mesh (like 9x9 or more). However, it take a lot of time and it's useless to probe all the plate for only a small part in the middle. This is where the adaptive bed mesh is helping.
 
 Here is how the magic happen:
-  1. The coordinates of the first layer corners are extracted from the slicer (currently work with SuperSlicer, PrusaSlicer and Cura)
+  1. The coordinates of the first layer corners are extracted either from the slicer (currently work with SuperSlicer, PrusaSlicer and Cura) or (since v3.0) directly from the `[exclude_object]` tags of Klipper
   2. On this area, a new set of points is computed to get at least the same precision (or better) as the original `[bed_mesh]` section. For example, if the `[bed_mesh]` section is set to 9×9 for a 300mm² bed, then it will compute for a 100mm² first layer surface a 3×3 mesh. Also if for whatever reason your parts are not in the center of the build plate (like when using a damaged PEI center), it will follow them to probe this exact area.
   3. The computed set of probed points is always odd: this allow the algorithm to compute a `relative_reference_index` point exactly in the center of the area. This point coordinates are saved in a variable if you need to use it somewhere else (like for example with the [klipper_z_calibration](https://github.com/protoloft/klipper_z_calibration) plugin and its `BED_POSITION` parameter).
   4. To go further, the adaptive bed mesh macro has also some smart features:
      - The shape of the computed mesh is not always a square and is always adapted to fit the first layer: for example, it can be something like 3×9 in case of an elongated part.
-     - In case of a very small part, the algorithm can choose automatically to not do any bed mesh at all if there is less than 3×3 points to probe.
+     - In case of a very small part, the algorithm can choose automatically to not do any bed mesh at all if there is less than 3×3 points to probe. If this behavior is not wanted because of a very bad bed, a mesh can still be forced using the `FORCE_MESH=1` parameter.
      - The macro can also choose and change automatically the interpolation algorithm between bicubic and lagrange depending of the size and shape of the mesh computed (like 3×3 vs 3×9) to always get the best precision.
 
 
@@ -22,26 +22,34 @@ Here is how the magic happen:
 If you installed and use the full config folder of this github repository, this is already enabled by default and should work out of the box.
 
 If you want to install it to your own custom config, here is the way to go:
-  1. Copy the [adaptive_bed_mesh.cfg](./../../macros/addons/adaptive_bed_mesh.cfg) macro file directly into your own config.
-  2. You need to change some settings in your slicer:
+  1. Copy the [adaptive_bed_mesh.cfg](./../../macros/addons/adaptive_bed_mesh.cfg) macro file directly into your own config and include it.
+  2. The macro needs the bounding box of the first layer to be able to compute a mesh on this surface. There is now two way to get it. Choose the one you prefer for your setup:
     
-     - **SuperSlicer** is easy. Just change your custom g_code PRINT_START macro to add the SIZE argument like this (everything should be on one line !):
+      - **The first way is the most easy** as you have nothing to do beside activating the `[exclude_object]` mechanisms of Moonraker and Klipper. To proceed, you can follow the excellent [Exclude Objects guide from the Mainsail team](https://docs.mainsail.xyz/features/exclude_objects). Then you can go to step 3.
+      
+        This method of extracting data was derived from [Kyleisah KAMP repository](https://github.com/kyleisah/Klipper-Adaptive-Meshing-Purging). Many thanks to him for the idea!
+      
+        Please note that only G-Code files that have been prepared accordingly will be able to use the adaptive mesh feature. For old and unprocessed files, a normal bed mesh will be automatically applied instead.
+      
+      - **If you want to do it the manual way**, you will need to change some settings in your slicer:
 
-       ```
-       PRINT_START [all your own things..] SIZE={first_layer_print_min[0]}_{first_layer_print_min[1]}_{first_layer_print_max[0]}_{first_layer_print_max[1]}
-       ```
+        - **SuperSlicer** is easy. Just change your custom g_code PRINT_START macro to add the SIZE argument like this (everything should be on one line !):
 
-     - **Cura** is a bit more tricky as you need to install the post process plugin by frankbags called MeshPrintSize.py.
+          ```
+          PRINT_START [all your own things..] SIZE={first_layer_print_min[0]}_{first_layer_print_min[1]}_{first_layer_print_max[0]}_{first_layer_print_max[1]}
+          ```
+
+        - **Cura** is a bit more tricky as you need to install the post process plugin by frankbags called MeshPrintSize.py.
      
-       In Cura menu, click `Help` > `Show configuration folder`. Then, copy [this python script](https://gist.github.com/frankbags/c85d37d9faff7bce67b6d18ec4e716ff#file-meshprintsize-py) into the plugins folder. Some users reported problems with newer versions of Cura, so if it's not working, try placing the script manually here: `C:\Program Files\Ultimaker Cura 5.0.0\share\cura\plugins\PostProcessingPlugin\scripts`.
+          In Cura menu, click `Help` > `Show configuration folder`. Then, copy [this python script](https://gist.github.com/frankbags/c85d37d9faff7bce67b6d18ec4e716ff#file-meshprintsize-py) into the plugins folder. Some users reported problems with newer versions of Cura, so if it's not working, try placing the script manually here: `C:\Program Files\Ultimaker Cura 5.0.0\share\cura\plugins\PostProcessingPlugin\scripts`.
      
-       Then restart Cura and select in the menu: `Extensions` > `Post processing` > select `Mesh Print Size`.
+          Then restart Cura and select in the menu: `Extensions` > `Post processing` > select `Mesh Print Size`.
      
-       At the end, change your custom g_code PRINT_START macro to add the SIZE argument like this (everything should be on one line !):
+          At the end, change your custom g_code PRINT_START macro to add the SIZE argument like this (everything should be on one line !):
      
-       ```
-       PRINT_START [all your own things...] SIZE=%MINX%_%MINY%_%MAXX%_%MAXY%
-       ```
+          ```
+          PRINT_START [all your own things...] SIZE=%MINX%_%MINY%_%MAXX%_%MAXY%
+          ```
 
   3. In klipper, if it's not already the case, add and configure a `[bed_mesh]` for your machine. This will be the base on which my macro compute the new adaptive bed mesh. Keep in mind that you can (and should) push the precision a little bit further: do not hesistate to go with a mesh of 9x9 (or even more) as with my adaptive bed mesh, not all the points will be probed for smaller parts.
 
@@ -53,11 +61,38 @@ If you want to install it to your own custom config, here is the way to go:
        probe_count: 9,9
        ```
 
-  5. My macro is using the `RESPOND` command of Klipper for debugging purposes. So, you need to: either be sure there is a `[respond]` section in your config (or add it). Or, if you don't want to see the messages, delete all the `RESPOND msg=...` lines in my macro.
+  5. My macro is using the `RESPOND` command of Klipper for debugging purposes. So, you need to: either be sure there is a `[respond]` section in your config (or add it). Or, if you don't want to see the messages, delete all the `RESPOND msg=...` lines.
 
 
 ## Usage
 
+
+<details>
+<summary>Using Exclude Objects</summary>
+There is two way to use this set of macros and do an adaptive bed mesh. Choose between the two points the one that is best for you:
+    
+  1. First way is the normal and easy way adapted for most of the users: in your klipper config, modify your `PRINT_START` macro definition by calling the `ADAPTIVE_BED_MESH` macro when you want to start the probing:
+     
+     ```
+     ADAPTIVE_BED_MESH
+     ```
+
+  2. Second way is for power users that also use the [klipper_z_calibration](https://github.com/protoloft/klipper_z_calibration) plugin and want to do the bed mesh **after** the Z calibration procedure. You will first need to add a call to `COMPUTE_MESH_PARAMETERS` somewhere in the beginning of your `PRINT_START`.
+             
+     Then you will need to call **in an another macro** the `CALIBRATE_Z` command with the computed mesh center point:
+
+     ```
+     {% set mesh_center = printer["gcode_macro _ADAPTIVE_MESH_VARIABLES"].mesh_center %}
+     CALIBRATE_Z BED_POSITION={mesh_center}
+     ```
+
+     Finally, do a simple call to `ADAPTIVE_BED_MESH` whenever you want to effectively do the mesh.
+
+     The *in an another macro* point is very important due to the way klipper is working and you will have troubles if you do not do this. For example, you can do it directly like me in the [CALIBRATE_Z overide](./../../macros/base/homing/z_calibration.cfg).
+</details>
+
+<details>
+<summary>Using the SIZE parameter from the slicer</summary>
 There is two way to use this set of macros and do an adaptive bed mesh. Choose between the two points the one that is best for you:
     
   1. First way is the normal and easy way adapted for most of the users: in your klipper config, modify your `PRINT_START` macro definition by adding two lines of gcode. The first one is to get the `SIZE` parameter from the slicer, and the second one is to call the `ADAPTIVE_BED_MESH` macro to start the probing. Something like that will do the trick:
@@ -84,7 +119,16 @@ There is two way to use this set of macros and do an adaptive bed mesh. Choose b
      Finally, do a simple call to `ADAPTIVE_BED_MESH` whenever you want to effectively do the mesh.
 
      The *in an another macro* point is very important due to the way klipper is working and you will have troubles if you do not do this. For example, you can do it directly like me in the [CALIBRATE_Z overide](./../../macros/base/homing/z_calibration.cfg).
+</details>
 
+
+Regarding the parameters availables, you can use them either when calling the `ADAPTIVE_BED_MESH` macro or the `COMPUTE_MESH_PARAMETERS` macro. Please see this table for details:
+
+| parameters | default value | description |
+|-----------:|---------------|-------------|
+|SIZE||"xMin_yMin_xMax_yMax" of the zone you want to do the mesh. Usually this is coming automatically from the slicer but this can still be used mannually when you want to call the adaptive mesh macro by hand (not during a print)|
+|MARGIN|5|margin in mm to add around the first layer for the probing area|
+|FORCE_MESH|0|force a 3×3 mesh even for very small parts (when less than 3×3 points are computed)|
 
 ## FAQ
 

--- a/macros/addons/adaptive_bed_mesh.cfg
+++ b/macros/addons/adaptive_bed_mesh.cfg
@@ -2,9 +2,14 @@
 ########## ADAPTIVE BED MESH ############
 #########################################
 # Written by Frix_x#0161 #
-# @version: 2.3
+# @version: 3.0
 
 # CHANGELOG:
+#   v3.0: - added the use of [exclude_object] tags to extract the first layer bounding box (many thanks to Kyleisah for the excellent idea and inspiration)
+#           the macro is still fully compatible with the old way using the SIZE parameter: it will use it if specified, or else
+#           fallback to the [exclude_object] method and if both are not available, it will do a full and normal bed mesh as usual.
+#         - also added a FORCE_MESH parameter to mesh even for very small parts
+#         - removed the RRI that was always added put in the BED_MESH_CALIBRATE call. Now it's added only when there is one defined in the [bed_mesh] section
 #   v2.3: moved the install notes into a proper markdown file in: doc > features > adaptive_bed_mesh.md
 #   v2.2: removed the requirement to set mesh_pps in the [bed_mesh] section. It's now again optional as it should be
 #   v2.1: fix for the nominal mesh (when no SIZE parameter is used or SIZE=0_0_0_0)
@@ -21,7 +26,7 @@
 # The adaptive bed mesh is simple: it's a normal bed mesh, but only "where" and "when" it's necessary.
 # Sometime I print small parts, sometime I print full plates and I like to get a precise bed_mesh (like 9x9 or more). However, it take a
 # lot of time and it's useless to probe all the plate for only a 5cm² part. So this is where the adaptive bed mesh is helping:
-# 1. It get the corners coordinates of the fisrt layer surface from the slicer
+# 1. It get the corners coordinates of the fisrt layer surface either from the slicer or the [exclude_object] tags
 # 2. It compute a new set of points to probe on this new zone to get at least the same precision as your standard bed mesh. For example, if
 #    a normal bed mesh is set to 9x9 for 300mm², it will then compute 3x3 for a 100mm² surface. Also if for whatever reason your parts are in
 #    the corner of the build plate (like for a damaged PEI in the center), it will follow them to probe this exact area.
@@ -56,15 +61,38 @@ gcode:
     {% set xMaxConf, yMaxConf = printer["configfile"].config["bed_mesh"]["mesh_max"].split(',')|map('trim')|map('int') %}
     {% set xProbeCntConf, yProbeCntConf = printer["configfile"].config["bed_mesh"]["probe_count"].split(',')|map('trim')|map('int') %}
     {% set algo = printer["configfile"].config["bed_mesh"]["algorithm"]|lower %}
-    {% set xMeshPPS, yMeshPPS = (printer["configfile"].config["bed_mesh"]["mesh_pps"] | default('2,2')).split(',')|map('trim')|map('int') %}
+    {% set xMeshPPS, yMeshPPS = (printer["configfile"].config["bed_mesh"]["mesh_pps"]|default('2,2')).split(',')|map('trim')|map('int') %}
 
-    # If the SIZE parameter is defined and not a dummy placeholder, we do the adaptive
-    # bed mesh logic. If it's ommited, we do the original BED_MESH_CALIBRATE function (full bed probing)
+    {% set margin = params.MARGIN|default(5)|int %} # additional margin to mesh around the first layer
+    {% set force_mesh = params.FORCE_MESH|default(False) %} # force the mesh even if it's a small part (ie. computed less than 3x3)
+
+
+    # 2 ----- GET FIRST LAYER COORDINATES and SIZE -------------------------------------
+    # If the SIZE parameter is defined and not a dummy placeholder, we use it to do the adaptive bed mesh logic
     {% if params.SIZE is defined and params.SIZE != "0_0_0_0" %}
-
-        # 2 ----- GET MESH SIZE AND MARGIN FROM MACRO CALL --------------------
+        RESPOND MSG="Got a SIZE parameter for the adaptive bed mesh"
         {% set xMinSpec, yMinSpec, xMaxSpec, yMaxSpec = params.SIZE.split('_')|map('trim')|map('int') %}
-        {% set margin = params.MARGIN|default(5)|int %}
+    
+    {% elif printer.exclude_object.objects %}
+        # Else if SIZE is not defined, we fallback to use the [exclude_object] tags
+        # This method is derived from Kyleisah KAMP repository: https://github.com/kyleisah/Klipper-Adaptive-Meshing-Purging)
+        RESPOND MSG="No SIZE parameter, using the [exclude_object] tags for the adaptive bed mesh"
+        {% set eo_points = printer.exclude_object.objects|map(attribute='polygon')|sum(start=[]) %}
+        {% set xMinSpec = eo_points|map(attribute=0)|min %}
+        {% set yMinSpec = eo_points|map(attribute=1)|min %}
+        {% set xMaxSpec = eo_points|map(attribute=0)|max %}
+        {% set yMaxSpec = eo_points|map(attribute=1)|max %}
+    
+    {% else %}
+        # Else if no SIZE parameter and no [exclude_object] tags, then we want to do a nominal bed mesh
+        # so nothing to do here...
+        RESPOND MSG="No info about the first layer coordinates, doing a nominal bed mesh instead of adaptive"
+    {% endif %}
+
+
+    # If the first layer size was correctly retrieved, we can do the adaptive bed mesh logic, else we
+    # fallback to the original and nominal BED_MESH_CALIBRATE function (full bed probing)
+    {% if xMinSpec and yMinSpec and xMaxSpec and yMaxSpec %}
 
         # 3 ----- APPLY MARGINS ----------------------------------------------
         # We use min/max function as we want it to be constrained by the original
@@ -81,20 +109,42 @@ gcode:
         {% set yProbeCnt = ((yMax - yMin) * yProbeCntConf / (yMaxConf - yMinConf))|round(0, 'ceil')|int %}
 
         # Then, three possibilities :
-        # a) Both dimensions have less than 3 probe points : the bed_mesh is not needed as it's a small print.
+        # a) Both dimensions have less than 3 probe points : the bed_mesh is not needed as it's a small print (if not forced).
         # b) If one of the dimension is less than 3 and the other is greater. The print looks to be elongated and
-        #    need the adaptive bed_mesh : we add probe points to the small direction to reach 3 and be able to do it.
+        #    need the adaptive bed_mesh : we add probing points to the small direction to reach 3 and be able to do it.
         # c) If both direction are greater than 3, we need the adaptive bed_mesh and it's ok.
         # At the end we control (according to Klipper bed_mesh method: "_verify_algorithm") that the computed probe_count is
         # valid according to the choosen algorithm or change it if needed.
         {% if xProbeCnt < 3 and yProbeCnt < 3 %}
-            RESPOND MSG="Computed mesh parameters: none, bed mesh not needed"
-            SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=do_mesh VALUE={False}
-
-            {% set xCenter = xMin + ((xMax - xMin) / 2) %}
-            {% set yCenter = yMin + ((yMax - yMin) / 2) %}
-            {% set mesh_center = "%d,%d"|format(xCenter, yCenter) %} # we still compute the mesh center for those using klipper_z_calibration
-            SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=mesh_center VALUE='"{mesh_center}"'
+            {% if force_mesh %}
+                RESPOND MSG="Bed mesh forced (small part detected): meshing 3x3..."
+                {% set xProbeCnt = 3 %}
+                {% set yProbeCnt = 3 %}
+                {% set rRefIndex = 4 %}
+                {% set algo = "lagrange" %}
+                {% set xCenter = xMin + ((xMax - xMin) / 2) %}
+                {% set yCenter = yMin + ((yMax - yMin) / 2) %}
+                {% set mesh_min = "%d,%d"|format(xMin, yMin) %}
+                {% set mesh_max = "%d,%d"|format(xMax, yMax) %}
+                {% set probe_count = "%d,%d"|format(xProbeCnt, yProbeCnt) %}
+                {% set mesh_center = "%d,%d"|format(xCenter, yCenter) %}
+                RESPOND MSG="Computed mesh parameters: MESH_MIN={mesh_min} MESH_MAX={mesh_max} MESH_CENTER={mesh_center} PROBE_COUNT={probe_count} RELATIVE_REFERENCE_INDEX={rRefIndex} ALGORITHM={algo}"
+                SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=do_mesh VALUE={True}
+                SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=do_nominal VALUE={False}
+                SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=mesh_min VALUE='"{mesh_min}"'
+                SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=mesh_max VALUE='"{mesh_max}"'
+                SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=mesh_center VALUE='"{mesh_center}"'
+                SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=probe_count VALUE='"{probe_count}"'
+                SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=rri VALUE={rRefIndex}
+                SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=algo VALUE='"{algo}"'
+            {% else %}
+                RESPOND MSG="Computed mesh parameters: none, bed mesh not needed for very small parts"
+                SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=do_mesh VALUE={False}
+                {% set xCenter = xMin + ((xMax - xMin) / 2) %}
+                {% set yCenter = yMin + ((yMax - yMin) / 2) %}
+                {% set mesh_center = "%d,%d"|format(xCenter, yCenter) %} # we still compute the mesh center for those using klipper_z_calibration
+                SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=mesh_center VALUE='"{mesh_center}"'
+            {% endif %}
         {% else %}
             {% set xProbeCnt = [3, xProbeCnt]|max %}
             {% set yProbeCnt = [3, yProbeCnt]|max %}
@@ -152,7 +202,6 @@ gcode:
             SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=algo VALUE='"{algo}"'
         {% endif %}
     {% else %}
-        RESPOND MSG="Computed mesh parameters: none, going for a nominal bed mesh"
         SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=do_mesh VALUE={True}
         SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=do_nominal VALUE={True}
 
@@ -182,7 +231,7 @@ gcode:
     # If the parameters where not computed prior to the ADAPTIVE_BED_MESH call, we call the COMPUTE_MESH_PARAMETERS
     # macro first and then call the _DO_ADAPTIVE_MESH macro after it
     {% else %}
-        RESPOND MSG="Adaptive bed mesh: parameters not computed, automatically calling the COMPUTE_MESH_PARAMETERS macro prior to the mesh"
+        RESPOND MSG="Adaptive bed mesh: parameters not already computed, automatically calling the COMPUTE_MESH_PARAMETERS macro prior to the mesh"
         COMPUTE_MESH_PARAMETERS {rawparams}
         M400 # mandatory to flush the gcode buffer and be sure to use the last computed parameters
         _DO_ADAPTIVE_MESH
@@ -209,8 +258,13 @@ gcode:
             RESPOND MSG="Adaptive bed mesh: nominal bed mesh"
             BED_MESH_CALIBRATE
         {% else %}
-            RESPOND MSG="Adaptive bed mesh: MESH_MIN={mesh_min} MESH_MAX={mesh_max} PROBE_COUNT={probe_count} RELATIVE_REFERENCE_INDEX={rRefIndex} ALGORITHM={algo}"
-            BED_MESH_CALIBRATE MESH_MIN={mesh_min} MESH_MAX={mesh_max} PROBE_COUNT={probe_count} RELATIVE_REFERENCE_INDEX={rRefIndex} ALGORITHM={algo}
+            {% if printer["configfile"].config["bed_mesh"]["relative_reference_index"] is defined %}
+                RESPOND MSG="Adaptive bed mesh: MESH_MIN={mesh_min} MESH_MAX={mesh_max} PROBE_COUNT={probe_count} RELATIVE_REFERENCE_INDEX={rRefIndex} ALGORITHM={algo}"
+                BED_MESH_CALIBRATE MESH_MIN={mesh_min} MESH_MAX={mesh_max} PROBE_COUNT={probe_count} RELATIVE_REFERENCE_INDEX={rRefIndex} ALGORITHM={algo}
+            {% else %}
+                RESPOND MSG="Adaptive bed mesh: MESH_MIN={mesh_min} MESH_MAX={mesh_max} PROBE_COUNT={probe_count} ALGORITHM={algo}"
+                BED_MESH_CALIBRATE MESH_MIN={mesh_min} MESH_MAX={mesh_max} PROBE_COUNT={probe_count} ALGORITHM={algo}
+            {% endif %}
         {% endif %}
     {% else %}
         RESPOND MSG="Adaptive bed mesh: no mesh to be done"


### PR DESCRIPTION
This is a WIP about the v3 of the adaptive bed mesh !

Changes:
  - added the use of [exclude_object] tags to extract the first layer bounding box (many thanks to Kyleisah for the excellent idea and inspiration) the macro is still fully compatible with the old way using the SIZE parameter: it will use it if specified, or else fallback to the [exclude_object] method and if both are not available, it will do a full and normal bed mesh as usual.
  - also added a FORCE_MESH parameter to mesh even for very small parts
  - removed the RRI that was always added put in the BED_MESH_CALIBRATE call. Now it's added only when there is one defined in the [bed_mesh] section
  - changed the RESPOND for a better user experience with more understandable messages

Kayleisah what do you think about it ? Is it ok for you with the credits like that ? Thanks a lot for the idea of using the exclude_objects from Klipper !