### PR TITLE
fix relative extrusion potential bug in the end_print macro

### DIFF
--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -17,6 +17,7 @@ gcode:
     {% else %}
         # pull back the filament a little bit
         _TIP_SHAPING
+		E92 E0				# Prevent error if the file printed was in relative extrusion mode
         G1 E-10 F2100
     {% endif %}     
 

--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -17,7 +17,8 @@ gcode:
     {% else %}
         # pull back the filament a little bit
         _TIP_SHAPING
-		E92 E0				# Prevent error if the file printed was in relative extrusion mode
+        # Put Extrusion in aboslute mode to prevent error if the file printed was in relative extrusion mode
+        E92 E0            
         G1 E-10 F2100
     {% endif %}     
 

--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -17,7 +17,6 @@ gcode:
     {% else %}
         # pull back the filament a little bit
         _TIP_SHAPING
-        # Put Extrusion in aboslute mode to prevent error if the file printed was in relative extrusion mode
         E92 E0            
         G1 E-10 F2100
     {% endif %}     

--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -17,7 +17,7 @@ gcode:
     {% else %}
         # pull back the filament a little bit
         _TIP_SHAPING
-        E92 E0            
+        G92 E0            
         G1 E-10 F2100
     {% endif %}     
 


### PR DESCRIPTION
# Add an E92 E0 command to prevent error if the file printed was in relative extrusion mode