### PR TITLE
QGL points and  gantry Corners per default config

### DIFF
--- a/config/hardware/default_250mm.cfg
+++ b/config/hardware/default_250mm.cfg
@@ -13,3 +13,12 @@ position_endstop: 0
 position_max: 210
 position_min: -5
 
+gantry_corners:
+   -60,-10
+   310, 320
+#  Probe points
+points:
+   50,25
+   50,175
+   200,175
+   200,25

--- a/config/hardware/default_300mm.cfg
+++ b/config/hardware/default_300mm.cfg
@@ -13,3 +13,12 @@ position_endstop: 0
 position_max: 260
 position_min: -5
 
+gantry_corners:
+   -60,-10
+   360,370
+#  Probe points
+points:
+   50,25
+   50,225
+   250,225
+   250,25

--- a/config/hardware/default_350mm.cfg
+++ b/config/hardware/default_350mm.cfg
@@ -12,3 +12,14 @@ position_endstop: 350
 #position_endstop: 0 # see probe config selection
 position_max: 310
 position_min: -5
+
+[quad_gantry_level]
+gantry_corners:
+   -60,-10
+   410,420
+#  Probe points
+points:
+   50,25
+   50,275
+   300,275
+   300,25

--- a/config/software/tilting/qgl.cfg
+++ b/config/software/tilting/qgl.cfg
@@ -11,14 +11,6 @@ gcode:
 
 
 [quad_gantry_level]
-gantry_corners:
-	-60,-10
-	360,370
-points:
-	50,25
-	50,225
-	250,225
-	250,25
 speed: 350
 horizontal_move_z: 12
 retries: 5


### PR DESCRIPTION
Suggestion for qgl points and gantry corner to be moved to each respective default config (per printer size / type) 
setup per standard voron config 
